### PR TITLE
Extensions added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,95 @@
 # ahbsd.lib
 Classes with functionality I miss
 
-- For example generic EventArgs or EventArgs for changing values. These two are in version 1.0.
-- In Version 1.0.1 some classes for generic API-Keys were added.
-- In Version 1.2.0 some code beautification was done, the license changes to Apache 2.0 and a generic Exception was added.
+- In **Version 1.0** *generic EventArgs* and *EventArgs for changing values* were added.
+- In **Version 1.0.1** some classes for *generic API-Keys* were added.
+- In **Version 1.2** some code beautification was done, the license changes to Apache 2.0 and a *generic Exception* was added.
+- In **Version 1.2.1** a tool for printing filled `DataTable` on the console was added.
+- In **Version 1.3** a class to check whether a given password is safe or not was added.
+- In **Version 1.4** `NamedCollections` were added.
+- In **Version 1.5** some functionality was added and a lot of *SonarLint* issues were removed.
+- In **Version 1.6** Extensions were added and used.
 
-## About generic EventArgs
+## Version 1.0:
+### About generic EventArgs:
 The generic EventArgs have a generic Value that could be set with the constructor.
 
-## About generic ChangeEventArgs
+### About generic ChangeEventArgs:
 The generic ChangeEventArgs have two generic values. One for the old value and one for the new value.
+
+## Version 1.4
+### About NamedCollections:
+Named collections have the main reason to be used in dictionaries which have as value a collection.
+The other way would be to have a dictionary with a dictionary as value which would have as key a string with the name of the collection…
+
+#### Example
+Doing this with Dictionaries it would look like:
+
+```c#
+Dictionary<int, IDictionary<string, ICollection<double>>> dExample = new Dictionary<int, IDictionary<string, ICollection<double>>>();
+IDictionary<string, ICollection<double>> tmp = new Dictionary<string, ICollection<double>>();
+ICollection<double> doubleCollection1 = new Collection<double>();
+tmp.Add("Double Collection 1", doubleCollection1);
+dExample.Add(1, tmp);
+dExample[1]["Double Collection 1"].Add(1.0);
+dExample[1]["Double Collection 1"].Add(1.1);
+dExample[1]["Double Collection 1"].Add(1.2);
+```
+
+With using ***IDictionaryOfNamedCollections*** it is much easier:
+
+```c#
+IDictionaryOfNamedCollections<int, double> dExample2 = new DictionaryOfNamedCollections<int, double>();
+dExample2.Add(2, 1.0, "Double Collection 2");
+dExample2.Add(2, 1.1);
+dExample2.Add(2, 1.2);
+```
+
+## Version 1.6
+Simplifing `string.IsNullOrEmpty()` and `string.IsNullOrWhiteSpace()` and the extraction of numbered lists in a `string`.
+
+### Example for the extraction
+If you have a numbered list, e.g.: `"1,2, 5, 99 ,8"` and want to get an *array* or *List* with the numbers, you can solve it e.g. like this:
+
+```c#
+string numberedList = "1,2, 5, 99 ,8";
+
+// for a result array:
+string[] numbers = numberedList.Split(',');
+int[] intNumbers = new int[numbers.Count];
+
+for (int i = 0; i < numbers.Count; i++)
+{
+    if (int.TryParse(numbers[i].Trim(), out int number)
+    {
+        intNumbers[i] = number;
+    }
+}
+
+// for a result list:
+IList<int> numberList = new List<int>();
+
+foreach (string sNumber in numberedList.Split(','))
+{
+    if (int.TryParse(sNumber.Trim(), out int number)
+    {
+        numberList.Add(number);
+    }
+}
+```
+
+much shorter (because the last part is more ore less included) is the following:
+
+```c#
+string numberedList = "1,2, 5, 99 ,8";
+IList<int> numberList = numberedList.GetIntList();
+```
+
+additionally the Extension also allows to set the splitter:
+
+```c#
+string numberedList = "1;2; 5; 99 ;8";
+IList<int> numberList = numberedList.GetIntList(';');
+```
 
 [![ahbsd.lib on fuget.org](https://www.fuget.org/packages/ahbsd.lib/badge.svg)](https://www.fuget.org/packages/ahbsd.lib)

--- a/Test_xUnit/ApiKey/ApiKeyTest.cs
+++ b/Test_xUnit/ApiKey/ApiKeyTest.cs
@@ -2,29 +2,32 @@
 using ahbsd.lib.ApiKey;
 using Xunit;
 
-namespace Test_xUnit.ApiKey;
-
-public class ApiKeyTest
+namespace Test_xUnit.ApiKey
 {
-
-    [Theory]
-    [InlineData("Test")]
-    [InlineData("Welt")]
-    [InlineData("hallo")]
-    public void ApiKeyHolderTest(string key)
+    public class ApiKeyTest
     {
-        ApiKeyHolder<string> testKeyHolder = new ApiKeyHolder<string>(key);
-        Assert.True(ApiKeyHolder<string>.FindApiKey(key) is >= 0);
-        int hc = testKeyHolder.GetHashCode();
-        Assert.True(hc != 0);
-        Assert.False(testKeyHolder.Equals(key));
-        Assert.True(testKeyHolder != null);
-        int? currentIdx = ApiKeyHolder<string>.FindApiKey(key);
 
-        if (currentIdx is > 0)
+        [Theory]
+        [InlineData("Test")]
+        [InlineData("Welt")]
+        [InlineData("hallo")]
+        public void ApiKeyHolderTest(string key)
         {
-            string previousKey = ApiKeyHolder<string>.GetApiKey(currentIdx.Value - 1);
-            Assert.NotEqual(previousKey, key);
+            ApiKeyHolder<string> testKeyHolder = new ApiKeyHolder<string>(key);
+            var keyId = ApiKeyHolder<string>.FindApiKey(key);
+            Assert.True(keyId >= 0);
+            int hc = testKeyHolder.GetHashCode();
+            Assert.True(hc != 0);
+            var isKeyExistent = testKeyHolder.Equals(key);
+            Assert.False(isKeyExistent);
+            Assert.True(testKeyHolder != null);
+            int? currentIdx = ApiKeyHolder<string>.FindApiKey(key);
+
+            if (currentIdx > 0)
+            {
+                string previousKey = ApiKeyHolder<string>.GetApiKey(currentIdx.Value - 1);
+                Assert.NotEqual(previousKey, key);
+            }
         }
     }
 }

--- a/Test_xUnit/Attributes/TestApiAttribute.cs
+++ b/Test_xUnit/Attributes/TestApiAttribute.cs
@@ -37,6 +37,7 @@ public class TestApiAttribute
         for (int i = 0; i < 3; i++)
         {
             ITestClass tmpObject = new TestClass($"#{i}");
+            Assert.Equal($"#{i}", tmpObject.Content);
             fiveObjects.Add(tmpObject);
         }
 
@@ -68,7 +69,6 @@ public class TestApiAttribute
 
 internal static class AttributeReader
 {
-
     public static CustomAttributeData GetFirstAttribute(object o)
     {
         CustomAttributeData result = null;
@@ -76,21 +76,16 @@ internal static class AttributeReader
         if (o != null)
         {
             var type = o.GetType();
-            try
-            {
-                result = type.CustomAttributes.First();
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-            }
+            
+            result = type.CustomAttributes.First();
+            Assert.NotNull(result);
         }
 
         return result;
     }
 }
 
-public interface ITestClass
+internal interface ITestClass
 {
     /// <summary>
     /// Gets the content.
@@ -100,16 +95,13 @@ public interface ITestClass
 }
 
 [Api]
-public class TestClass : ITestClass
+internal class TestClass : ITestClass
 {
     /// <summary>
     /// Constructor with optional content.
     /// </summary>
     /// <param name="content">[optional] content</param>
-    public TestClass(string content = null)
-    {
-        Content = content;
-    }
+    public TestClass(string content = null) => Content = content;
 
     /// <inheritdoc/>
     public string Content { get; }

--- a/Test_xUnit/Attributes/TestApiAttribute.cs
+++ b/Test_xUnit/Attributes/TestApiAttribute.cs
@@ -25,84 +25,85 @@ using System.Reflection;
 using ahbsd.lib.Attributes;
 using Xunit;
 
-namespace Test_xUnit.Attributes;
-
-public class TestApiAttribute
+namespace Test_xUnit.Attributes
 {
-    [Fact]
-    public void Test5TestClasses()
+    public class TestApiAttribute
     {
-        ICollection<ITestClass> fiveObjects = new List<ITestClass>(5);
-
-        for (int i = 0; i < 3; i++)
+        [Fact]
+        public void Test5TestClasses()
         {
-            ITestClass tmpObject = new TestClass($"#{i}");
-            Assert.Equal($"#{i}", tmpObject.Content);
-            fiveObjects.Add(tmpObject);
-        }
+            ICollection<ITestClass> fiveObjects = new List<ITestClass>(5);
 
-        TestClass test4 = new TestClass();
-        var test5 = new TestClass();
-
-        fiveObjects.Add(test4);
-        fiveObjects.Add(test5);
-
-        foreach (var fiveObject in fiveObjects)
-        {
-            Assert.Contains("Api", AttributeReader.GetFirstAttribute(fiveObject).ToString());
-        }
-
-        try
-        {
-            foreach (var usingType in ApiAttribute.UsingTypes)
+            for (int i = 0; i < 3; i++)
             {
-                Assert.Equal(typeof(TestClass), usingType);
+                ITestClass tmpObject = new TestClass($"#{i}");
+                Assert.Equal($"#{i}", tmpObject.Content);
+                fiveObjects.Add(tmpObject);
             }
-        }
-        catch (Exception)
-        {
-            // we don't care
-        }
+
+            TestClass test4 = new TestClass();
+            var test5 = new TestClass();
+
+            fiveObjects.Add(test4);
+            fiveObjects.Add(test5);
+
+            foreach (var fiveObject in fiveObjects)
+            {
+                Assert.Contains("Api", AttributeReader.GetFirstAttribute(fiveObject).ToString());
+            }
+
+            try
+            {
+                foreach (var usingType in ApiAttribute.UsingTypes)
+                {
+                    Assert.Equal(typeof(TestClass), usingType);
+                }
+            }
+            catch (Exception)
+            {
+                // we don't care
+            }
         
-    }
-}
-
-internal static class AttributeReader
-{
-    public static CustomAttributeData GetFirstAttribute(object o)
-    {
-        CustomAttributeData result = null;
-
-        if (o != null)
-        {
-            var type = o.GetType();
-            
-            result = type.CustomAttributes.First();
-            Assert.NotNull(result);
         }
-
-        return result;
     }
-}
 
-internal interface ITestClass
-{
-    /// <summary>
-    /// Gets the content.
-    /// </summary>
-    /// <value>The content</value>
-    string Content { get; }
-}
+    internal static class AttributeReader
+    {
+        public static CustomAttributeData GetFirstAttribute(object o)
+        {
+            CustomAttributeData result = null;
 
-[Api]
-internal class TestClass : ITestClass
-{
-    /// <summary>
-    /// Constructor with optional content.
-    /// </summary>
-    /// <param name="content">[optional] content</param>
-    public TestClass(string content = null) => Content = content;
+            if (o != null)
+            {
+                var type = o.GetType();
+            
+                result = type.CustomAttributes.First();
+                Assert.NotNull(result);
+            }
 
-    /// <inheritdoc/>
-    public string Content { get; }
+            return result;
+        }
+    }
+
+    internal interface ITestClass
+    {
+        /// <summary>
+        /// Gets the content.
+        /// </summary>
+        /// <value>The content</value>
+        string Content { get; }
+    }
+
+    [Api]
+    internal class TestClass : ITestClass
+    {
+        /// <summary>
+        /// Constructor with optional content.
+        /// </summary>
+        /// <param name="content">[optional] content</param>
+        public TestClass(string content = null) => Content = content;
+
+        /// <inheritdoc/>
+        public string Content { get; }
+    }
 }

--- a/Test_xUnit/Collections/TestCollectionAddEventArgs.cs
+++ b/Test_xUnit/Collections/TestCollectionAddEventArgs.cs
@@ -24,22 +24,23 @@ using ahbsd.lib.Interfaces;
 using ahbsd.lib.Tools;
 using Xunit;
 
-namespace Test_xUnit.Collections;
-
-public class TestCollectionAddEventArgs
+namespace Test_xUnit.Collections
 {
-    private static readonly ILogger testLogger = new Logger("Test.log");
-    [Fact]
-    public void SimpleTest()
+    public class TestCollectionAddEventArgs
     {
-        ICollection<string> col1 = new List<string>();
-        var item = "SimpleTest";
-        testLogger.Log($"Starting {GetType().Name}.{item}");
-        col1.Add(item);
-        ICollectionAddEventArgs<string> collectionAddEventArgs = new CollectionAddEventArgs<string>(col1, item);
+        private static readonly ILogger testLogger = new Logger("Test.log");
+        [Fact]
+        public void SimpleTest()
+        {
+            ICollection<string> col1 = new List<string>();
+            var item = "SimpleTest";
+            testLogger.Log($"Starting {GetType().Name}.{item}");
+            col1.Add(item);
+            ICollectionAddEventArgs<string> collectionAddEventArgs = new CollectionAddEventArgs<string>(col1, item);
             
-        Assert.Equal(item, collectionAddEventArgs.Value);
-        Assert.Equal(col1, collectionAddEventArgs.AffectedCollection);
-        testLogger.Log("Test finished");
+            Assert.Equal(item, collectionAddEventArgs.Value);
+            Assert.Equal(col1, collectionAddEventArgs.AffectedCollection);
+            testLogger.Log("Test finished");
+        }
     }
 }

--- a/Test_xUnit/Collections/TestSourceDirectories.cs
+++ b/Test_xUnit/Collections/TestSourceDirectories.cs
@@ -19,6 +19,7 @@
 // 
 
 using System.Collections.Generic;
+using System.IO;
 using ahbsd.lib.Collections;
 using ahbsd.lib.EventArgs;
 using ahbsd.lib.Interfaces;
@@ -29,12 +30,12 @@ namespace Test_xUnit.Collections;
 
 public class TestSourceDirectories
 {
-    private static readonly ILogger testLogger = new Logger("Test.log");
+    private static readonly ILogger TestLogger = new Logger($"{Path.GetTempPath()}Test.log");
     
     [Fact]
     public void SourceDirectoryTest()
     {
-        testLogger.Log($"Starting Fact {GetType().Name}.SourceDirectoryTest");
+        TestLogger.Log($"Starting Fact {GetType().Name}.SourceDirectoryTest");
         ISourceDirectories directories = new SourceDirectories();
         
         directories.OnNewDirectoryAdded += DirectoriesOnOnNewDirectoryAdded;
@@ -44,12 +45,12 @@ public class TestSourceDirectories
         IReadOnlyCollection<string> readOnlyCollection = directories.AsReadonly;
         
         Assert.Equal(directories, readOnlyCollection);
-        testLogger.Log("Finished test");
+        TestLogger.Log("Finished test");
     }
 
     private void DirectoriesOnOnNewDirectoryAdded(object sender, CollectionAddEventArgs<string> e)
     {
-        testLogger.Log($"Sender '{sender}': {e}");
+        TestLogger.Log($"Sender '{sender}': {e}");
         Assert.Equal(1, e.AffectedCollection.Count);
         Assert.Equal("Test", e.Value);
     }

--- a/Test_xUnit/Collections/TestSourceDirectories.cs
+++ b/Test_xUnit/Collections/TestSourceDirectories.cs
@@ -26,32 +26,33 @@ using ahbsd.lib.Interfaces;
 using ahbsd.lib.Tools;
 using Xunit;
 
-namespace Test_xUnit.Collections;
-
-public class TestSourceDirectories
+namespace Test_xUnit.Collections
 {
-    private static readonly ILogger TestLogger = new Logger($"{Path.GetTempPath()}Test.log");
+    public class TestSourceDirectories
+    {
+        private static readonly ILogger TestLogger = new Logger($"{Path.GetTempPath()}Test.log");
     
-    [Fact]
-    public void SourceDirectoryTest()
-    {
-        TestLogger.Log($"Starting Fact {GetType().Name}.SourceDirectoryTest");
-        ISourceDirectories directories = new SourceDirectories();
+        [Fact]
+        public void SourceDirectoryTest()
+        {
+            TestLogger.Log($"Starting Fact {GetType().Name}.SourceDirectoryTest");
+            ISourceDirectories directories = new SourceDirectories();
         
-        directories.OnNewDirectoryAdded += DirectoriesOnOnNewDirectoryAdded;
+            directories.OnNewDirectoryAdded += DirectoriesOnOnNewDirectoryAdded;
 
-        directories.Add("Test");
+            directories.Add("Test");
 
-        IReadOnlyCollection<string> readOnlyCollection = directories.AsReadonly;
+            IReadOnlyCollection<string> readOnlyCollection = directories.AsReadonly;
         
-        Assert.Equal(directories, readOnlyCollection);
-        TestLogger.Log("Finished test");
-    }
+            Assert.Equal(directories, readOnlyCollection);
+            TestLogger.Log("Finished test");
+        }
 
-    private void DirectoriesOnOnNewDirectoryAdded(object sender, CollectionAddEventArgs<string> e)
-    {
-        TestLogger.Log($"Sender '{sender}': {e}");
-        Assert.Equal(1, e.AffectedCollection.Count);
-        Assert.Equal("Test", e.Value);
+        private void DirectoriesOnOnNewDirectoryAdded(object sender, CollectionAddEventArgs<string> e)
+        {
+            TestLogger.Log($"Sender '{sender}': {e}");
+            Assert.Equal(1, e.AffectedCollection.Count);
+            Assert.Equal("Test", e.Value);
+        }
     }
 }

--- a/Test_xUnit/Components/TestLoggerComponent.cs
+++ b/Test_xUnit/Components/TestLoggerComponent.cs
@@ -27,51 +27,52 @@ using ahbsd.lib.EventArgs;
 using ahbsd.lib.Interfaces;
 using ahbsd.lib.Tools;
 
-namespace Test_xUnit.Components;
-
-public class TestLoggerComponent
+namespace Test_xUnit.Components
 {
-
-    private static readonly ILogger TestLogger = new Logger($"{Path.GetTempPath()}Test.log");
-
-    [Fact]
-    public void LoggerTest()
+    public class TestLoggerComponent
     {
-        TestLogger.Log($"Starting FACT {GetType().Name}.LoggerTest");
 
-        var logger = TestLogger;
-        Assert.Equal($"{Path.GetTempPath()}Test.log", logger.Logfile);
-        
-        Assert.Equal("Logger", logger.Name);
-        logger.Log($"The name of logger is '{logger.Name}'");
+        private static readonly ILogger TestLogger = new Logger($"{Path.GetTempPath()}Test.log");
 
-        logger = new LoggerComponent(new Container(), "TestLogger");
-        logger.OnLogfileChanged += Logger_OnLogfileChanged;
-        logger.Logfile = TestLogger.Logfile;
-        
-        logger.Log($"The Name should be 'TestLogger' and is currently '{logger.Name}'");
-        
-
-        var loggerComponent = new LoggerComponent();
-        Assert.Equal("LoggerComponent", loggerComponent.Name);
-        loggerComponent.Disposed += LoggerComponent_Disposed;
-        
-        loggerComponent.Dispose();
-        TestLogger.Log("Finished test");
-    }
-
-    private void LoggerComponent_Disposed(object sender, EventArgs e)
-    {
-        if (sender is IDisposable disposable)
+        [Fact]
+        public void LoggerTest()
         {
-            TestLogger.Log($"Sender {sender} disposed: {disposable}");
-        }
-    }
+            TestLogger.Log($"Starting FACT {GetType().Name}.LoggerTest");
 
-    private void Logger_OnLogfileChanged(object sender, ChangeEventArgs<string> e)
-    {
-        var ceaString = e.ToString();
-        TestLogger.Log($"OnLogfileChanged was send by '{sender}' with change event arguments:\n{ceaString}");
-        Assert.NotEqual(e.OldValue, e.NewValue);
+            var logger = TestLogger;
+            Assert.Equal($"{Path.GetTempPath()}Test.log", logger.Logfile);
+        
+            Assert.Equal("Logger", logger.Name);
+            logger.Log($"The name of logger is '{logger.Name}'");
+
+            logger = new LoggerComponent(new Container(), "TestLogger");
+            logger.OnLogfileChanged += Logger_OnLogfileChanged;
+            logger.Logfile = TestLogger.Logfile;
+        
+            logger.Log($"The Name should be 'TestLogger' and is currently '{logger.Name}'");
+        
+
+            var loggerComponent = new LoggerComponent();
+            Assert.Equal("LoggerComponent", loggerComponent.Name);
+            loggerComponent.Disposed += LoggerComponent_Disposed;
+        
+            loggerComponent.Dispose();
+            TestLogger.Log("Finished test");
+        }
+
+        private void LoggerComponent_Disposed(object sender, EventArgs e)
+        {
+            if (sender is IDisposable disposable)
+            {
+                TestLogger.Log($"Sender {sender} disposed: {disposable}");
+            }
+        }
+
+        private void Logger_OnLogfileChanged(object sender, ChangeEventArgs<string> e)
+        {
+            var ceaString = e.ToString();
+            TestLogger.Log($"OnLogfileChanged was send by '{sender}' with change event arguments:\n{ceaString}");
+            Assert.NotEqual(e.OldValue, e.NewValue);
+        }
     }
 }

--- a/Test_xUnit/Components/TestLoggerComponent.cs
+++ b/Test_xUnit/Components/TestLoggerComponent.cs
@@ -20,6 +20,7 @@
 
 using System;
 using System.ComponentModel;
+using System.IO;
 using Xunit;
 using ahbsd.lib.Components;
 using ahbsd.lib.EventArgs;
@@ -30,22 +31,23 @@ namespace Test_xUnit.Components;
 
 public class TestLoggerComponent
 {
-    private static readonly ILogger testLogger = new Logger("Test.log");
+
+    private static readonly ILogger TestLogger = new Logger($"{Path.GetTempPath()}Test.log");
 
     [Fact]
     public void LoggerTest()
     {
-        testLogger.Log($"Starting FACT {GetType().Name}.LoggerTest");
+        TestLogger.Log($"Starting FACT {GetType().Name}.LoggerTest");
 
-        var logger = testLogger;
-        Assert.Equal("Test.log", logger.Logfile);
+        var logger = TestLogger;
+        Assert.Equal($"{Path.GetTempPath()}Test.log", logger.Logfile);
         
         Assert.Equal("Logger", logger.Name);
         logger.Log($"The name of logger is '{logger.Name}'");
 
         logger = new LoggerComponent(new Container(), "TestLogger");
         logger.OnLogfileChanged += Logger_OnLogfileChanged;
-        logger.Logfile = testLogger.Logfile;
+        logger.Logfile = TestLogger.Logfile;
         
         logger.Log($"The Name should be 'TestLogger' and is currently '{logger.Name}'");
         
@@ -55,21 +57,21 @@ public class TestLoggerComponent
         loggerComponent.Disposed += LoggerComponent_Disposed;
         
         loggerComponent.Dispose();
-        testLogger.Log("Finished test");
+        TestLogger.Log("Finished test");
     }
 
     private void LoggerComponent_Disposed(object sender, EventArgs e)
     {
         if (sender is IDisposable disposable)
         {
-            testLogger.Log($"Sender {sender} disposed: {disposable}");
+            TestLogger.Log($"Sender {sender} disposed: {disposable}");
         }
     }
 
     private void Logger_OnLogfileChanged(object sender, ChangeEventArgs<string> e)
     {
         var ceaString = e.ToString();
-        testLogger.Log($"OnLogfileChanged was send by '{sender}' with change event arguments:\n{ceaString}");
+        TestLogger.Log($"OnLogfileChanged was send by '{sender}' with change event arguments:\n{ceaString}");
         Assert.NotEqual(e.OldValue, e.NewValue);
     }
 }

--- a/Test_xUnit/Exceptions/TestExceptions.cs
+++ b/Test_xUnit/Exceptions/TestExceptions.cs
@@ -41,10 +41,10 @@ namespace Test_xUnit.Exceptions
         }
 
         [Theory]
-        [InlineData(null, null, 1)]
-        [InlineData(25d, 24, 1)]
+        [InlineData(null, null, 1d)]
+        [InlineData(25d, 24d, 1d)]
         [InlineData(3.14, 3.1415, 3.14158)]
-        [InlineData(22, 23, 24)]
+        [InlineData(22d, 23d, 24d)]
         public void AlreadySetDoubleChangeEventArgs(double? oldValue, double? newValue1, double? newValue2)
         {
             ChangeEventArgs<double?> changeEventArgs1 = new ChangeEventArgs<double?>(oldValue);

--- a/Test_xUnit/Extensions/StringExtensionsTest.cs
+++ b/Test_xUnit/Extensions/StringExtensionsTest.cs
@@ -1,147 +1,148 @@
 ﻿using ahbsd.lib.Extensions;
 using Xunit;
 
-namespace Test_xUnit.Extensions;
-
-public class StringExtensionsTest
+namespace Test_xUnit.Extensions
 {
-    [Theory]
-    [InlineData("bla", false)]
-    [InlineData("", true)]
-    [InlineData(" ", false)]
-    [InlineData("                                   ", false)]
-    [InlineData(null, true)]
-    public void TestIsNullOrEmpty(string value, bool expectedResult)
+    public class StringExtensionsTest
     {
-        var result = value.IsNullOrEmpty();
-        Assert.Equal(expectedResult, result);
-    }
+        [Theory]
+        [InlineData("bla", false)]
+        [InlineData("", true)]
+        [InlineData(" ", false)]
+        [InlineData("                                   ", false)]
+        [InlineData(null, true)]
+        public void TestIsNullOrEmpty(string value, bool expectedResult)
+        {
+            var result = value.IsNullOrEmpty();
+            Assert.Equal(expectedResult, result);
+        }
 
-    [Theory]
-    [InlineData("bla", false)]
-    [InlineData("", true)]
-    [InlineData(" ", true)]
-    [InlineData("                                   ", true)]
-    [InlineData(null, true)]
-    public void TestIsNullOrWhiteSpace(string value, bool expectedResult)
-    {
-        var result = value.IsNullOrWhiteSpace();
-        Assert.Equal(expectedResult, result);
-    }
+        [Theory]
+        [InlineData("bla", false)]
+        [InlineData("", true)]
+        [InlineData(" ", true)]
+        [InlineData("                                   ", true)]
+        [InlineData(null, true)]
+        public void TestIsNullOrWhiteSpace(string value, bool expectedResult)
+        {
+            var result = value.IsNullOrWhiteSpace();
+            Assert.Equal(expectedResult, result);
+        }
 
-    [Fact]
-    public void TestGetIntList()
-    {
-        const string numberedList = "1,2, 5, 99 ,8";
-        var intList = numberedList.GetIntList();
-        Assert.Equal(1, intList[0]);
-        Assert.Equal(2, intList[1]);
-        Assert.Equal(5, intList[2]);
-        Assert.Equal(99, intList[3]);
-        Assert.Equal(8, intList[4]);
-    }
+        [Fact]
+        public void TestGetIntList()
+        {
+            const string numberedList = "1,2, 5, 99 ,8";
+            var intList = numberedList.GetIntList();
+            Assert.Equal(1, intList[0]);
+            Assert.Equal(2, intList[1]);
+            Assert.Equal(5, intList[2]);
+            Assert.Equal(99, intList[3]);
+            Assert.Equal(8, intList[4]);
+        }
     
-    [Fact]
-    public void TestGetIntListEmpty()
-    {
-        var numberedList = string.Empty;
-        var intList = numberedList.GetIntList();
-        Assert.Equal(0, intList.Count);
-    }
+        [Fact]
+        public void TestGetIntListEmpty()
+        {
+            var numberedList = string.Empty;
+            var intList = numberedList.GetIntList();
+            Assert.Equal(0, intList.Count);
+        }
     
-    [Fact]
-    public void TestGetIntListNull()
-    {
-        string numberedList = null;
-        var intList = numberedList.GetIntList();
-        Assert.Null(intList);
-    }
+        [Fact]
+        public void TestGetIntListNull()
+        {
+            string numberedList = null;
+            var intList = numberedList.GetIntList();
+            Assert.Null(intList);
+        }
     
-    [Fact]
-    public void TestGetIntDictEmpty()
-    {
-        var numberedList = string.Empty;
-        var intList = numberedList.GetIntDictionary();
-        Assert.Equal(0, intList.Count);
-    }
+        [Fact]
+        public void TestGetIntDictEmpty()
+        {
+            var numberedList = string.Empty;
+            var intList = numberedList.GetIntDictionary();
+            Assert.Equal(0, intList.Count);
+        }
     
-    [Fact]
-    public void TestGetIntDictNull()
-    {
-        string numberedList = null;
-        var intList = numberedList.GetIntDictionary();
-        Assert.Null(intList);
-    }
+        [Fact]
+        public void TestGetIntDictNull()
+        {
+            string numberedList = null;
+            var intList = numberedList.GetIntDictionary();
+            Assert.Null(intList);
+        }
     
-    [Theory]
-    [InlineData("1,2, 5, 99 ,8", 1,2,5,99,8)]
-    [InlineData("1,2, 5, 99 ,a", 1,2,5,99,null)]
-    [InlineData("1,2, 5, -99 ,8", 1,2,5,-99,8)]
-    [InlineData("1,20, z, 99 ,8", 1,20,99,8, null)]
-    [InlineData("1,zwei, fünf, 9 ,8", 1,9,8,null,null)]
-    public void TestGetIntListTheory(string numberedList, int? nr0, int? nr1, int? nr2, int? nr3, int? nr4)
-    {
-        var intList = numberedList.GetIntList();
-
-        if (intList.Count > 0 && nr0.HasValue)
+        [Theory]
+        [InlineData("1,2, 5, 99 ,8", 1,2,5,99,8)]
+        [InlineData("1,2, 5, 99 ,a", 1,2,5,99,null)]
+        [InlineData("1,2, 5, -99 ,8", 1,2,5,-99,8)]
+        [InlineData("1,20, z, 99 ,8", 1,20,99,8, null)]
+        [InlineData("1,zwei, fünf, 9 ,8", 1,9,8,null,null)]
+        public void TestGetIntListTheory(string numberedList, int? nr0, int? nr1, int? nr2, int? nr3, int? nr4)
         {
-            Assert.Equal(nr0.Value, intList[0]);
-        }
+            var intList = numberedList.GetIntList();
 
-        if (intList.Count > 1 && nr1.HasValue)
-        {
-            Assert.Equal(nr1.Value, intList[1]);
-        }
+            if (intList.Count > 0 && nr0.HasValue)
+            {
+                Assert.Equal(nr0.Value, intList[0]);
+            }
 
-        if (intList.Count > 2 && nr2.HasValue)
-        {
-            Assert.Equal(nr2.Value, intList[2]);
-        }
+            if (intList.Count > 1 && nr1.HasValue)
+            {
+                Assert.Equal(nr1.Value, intList[1]);
+            }
 
-        if (intList.Count > 3 && nr3.HasValue)
-        {
-            Assert.Equal(nr3.Value, intList[3]);
-        }
+            if (intList.Count > 2 && nr2.HasValue)
+            {
+                Assert.Equal(nr2.Value, intList[2]);
+            }
 
-        if (intList.Count > 4 && nr4.HasValue)
-        {
-            Assert.Equal(nr4.Value, intList[4]);
+            if (intList.Count > 3 && nr3.HasValue)
+            {
+                Assert.Equal(nr3.Value, intList[3]);
+            }
+
+            if (intList.Count > 4 && nr4.HasValue)
+            {
+                Assert.Equal(nr4.Value, intList[4]);
+            }
         }
-    }
     
-    [Theory]
-    [InlineData("1,2, 5, 99 ,8", 1,2,5,99,8)]
-    [InlineData("1,2, 5, 99 ,a", 1,2,5,99,null)]
-    [InlineData("1,2, 5, -99 ,8", 1,2,5,-99,8)]
-    [InlineData("1,20, z, 99 ,8", 1,20,99,8, null)]
-    [InlineData("1,zwei, fünf, 9 ,8", 1,9,8,null,null)]
-    public void TestGetIntDictTheory(string numberedList, int? nr0, int? nr1, int? nr2, int? nr3, int? nr4)
-    {
-        var intList = numberedList.GetIntDictionary();
-
-        if (intList.Count > 0 && nr0.HasValue)
+        [Theory]
+        [InlineData("1,2, 5, 99 ,8", 1,2,5,99,8)]
+        [InlineData("1,2, 5, 99 ,a", 1,2,5,99,null)]
+        [InlineData("1,2, 5, -99 ,8", 1,2,5,-99,8)]
+        [InlineData("1,20, z, 99 ,8", 1,20,99,8, null)]
+        [InlineData("1,zwei, fünf, 9 ,8", 1,9,8,null,null)]
+        public void TestGetIntDictTheory(string numberedList, int? nr0, int? nr1, int? nr2, int? nr3, int? nr4)
         {
-            Assert.Equal(nr0.Value, intList[0]);
-        }
+            var intList = numberedList.GetIntDictionary();
 
-        if (intList.Count > 1 && nr1.HasValue)
-        {
-            Assert.Equal(nr1.Value, intList[1]);
-        }
+            if (intList.Count > 0 && nr0.HasValue)
+            {
+                Assert.Equal(nr0.Value, intList[0]);
+            }
 
-        if (intList.Count > 2 && nr2.HasValue)
-        {
-            Assert.Equal(nr2.Value, intList[2]);
-        }
+            if (intList.Count > 1 && nr1.HasValue)
+            {
+                Assert.Equal(nr1.Value, intList[1]);
+            }
 
-        if (intList.Count > 3 && nr3.HasValue)
-        {
-            Assert.Equal(nr3.Value, intList[3]);
-        }
+            if (intList.Count > 2 && nr2.HasValue)
+            {
+                Assert.Equal(nr2.Value, intList[2]);
+            }
 
-        if (intList.Count > 4 && nr4.HasValue)
-        {
-            Assert.Equal(nr4.Value, intList[4]);
+            if (intList.Count > 3 && nr3.HasValue)
+            {
+                Assert.Equal(nr3.Value, intList[3]);
+            }
+
+            if (intList.Count > 4 && nr4.HasValue)
+            {
+                Assert.Equal(nr4.Value, intList[4]);
+            }
         }
     }
 }

--- a/Test_xUnit/Extensions/StringExtensionsTest.cs
+++ b/Test_xUnit/Extensions/StringExtensionsTest.cs
@@ -1,0 +1,147 @@
+﻿using ahbsd.lib.Extensions;
+using Xunit;
+
+namespace Test_xUnit.Extensions;
+
+public class StringExtensionsTest
+{
+    [Theory]
+    [InlineData("bla", false)]
+    [InlineData("", true)]
+    [InlineData(" ", false)]
+    [InlineData("                                   ", false)]
+    [InlineData(null, true)]
+    public void TestIsNullOrEmpty(string value, bool expectedResult)
+    {
+        var result = value.IsNullOrEmpty();
+        Assert.Equal(expectedResult, result);
+    }
+
+    [Theory]
+    [InlineData("bla", false)]
+    [InlineData("", true)]
+    [InlineData(" ", true)]
+    [InlineData("                                   ", true)]
+    [InlineData(null, true)]
+    public void TestIsNullOrWhiteSpace(string value, bool expectedResult)
+    {
+        var result = value.IsNullOrWhiteSpace();
+        Assert.Equal(expectedResult, result);
+    }
+
+    [Fact]
+    public void TestGetIntList()
+    {
+        const string numberedList = "1,2, 5, 99 ,8";
+        var intList = numberedList.GetIntList();
+        Assert.Equal(1, intList[0]);
+        Assert.Equal(2, intList[1]);
+        Assert.Equal(5, intList[2]);
+        Assert.Equal(99, intList[3]);
+        Assert.Equal(8, intList[4]);
+    }
+    
+    [Fact]
+    public void TestGetIntListEmpty()
+    {
+        var numberedList = string.Empty;
+        var intList = numberedList.GetIntList();
+        Assert.Equal(0, intList.Count);
+    }
+    
+    [Fact]
+    public void TestGetIntListNull()
+    {
+        string numberedList = null;
+        var intList = numberedList.GetIntList();
+        Assert.Null(intList);
+    }
+    
+    [Fact]
+    public void TestGetIntDictEmpty()
+    {
+        var numberedList = string.Empty;
+        var intList = numberedList.GetIntDictionary();
+        Assert.Equal(0, intList.Count);
+    }
+    
+    [Fact]
+    public void TestGetIntDictNull()
+    {
+        string numberedList = null;
+        var intList = numberedList.GetIntDictionary();
+        Assert.Null(intList);
+    }
+    
+    [Theory]
+    [InlineData("1,2, 5, 99 ,8", 1,2,5,99,8)]
+    [InlineData("1,2, 5, 99 ,a", 1,2,5,99,null)]
+    [InlineData("1,2, 5, -99 ,8", 1,2,5,-99,8)]
+    [InlineData("1,20, z, 99 ,8", 1,20,99,8, null)]
+    [InlineData("1,zwei, fünf, 9 ,8", 1,9,8,null,null)]
+    public void TestGetIntListTheory(string numberedList, int? nr0, int? nr1, int? nr2, int? nr3, int? nr4)
+    {
+        var intList = numberedList.GetIntList();
+
+        if (intList.Count > 0 && nr0.HasValue)
+        {
+            Assert.Equal(nr0.Value, intList[0]);
+        }
+
+        if (intList.Count > 1 && nr1.HasValue)
+        {
+            Assert.Equal(nr1.Value, intList[1]);
+        }
+
+        if (intList.Count > 2 && nr2.HasValue)
+        {
+            Assert.Equal(nr2.Value, intList[2]);
+        }
+
+        if (intList.Count > 3 && nr3.HasValue)
+        {
+            Assert.Equal(nr3.Value, intList[3]);
+        }
+
+        if (intList.Count > 4 && nr4.HasValue)
+        {
+            Assert.Equal(nr4.Value, intList[4]);
+        }
+    }
+    
+    [Theory]
+    [InlineData("1,2, 5, 99 ,8", 1,2,5,99,8)]
+    [InlineData("1,2, 5, 99 ,a", 1,2,5,99,null)]
+    [InlineData("1,2, 5, -99 ,8", 1,2,5,-99,8)]
+    [InlineData("1,20, z, 99 ,8", 1,20,99,8, null)]
+    [InlineData("1,zwei, fünf, 9 ,8", 1,9,8,null,null)]
+    public void TestGetIntDictTheory(string numberedList, int? nr0, int? nr1, int? nr2, int? nr3, int? nr4)
+    {
+        var intList = numberedList.GetIntDictionary();
+
+        if (intList.Count > 0 && nr0.HasValue)
+        {
+            Assert.Equal(nr0.Value, intList[0]);
+        }
+
+        if (intList.Count > 1 && nr1.HasValue)
+        {
+            Assert.Equal(nr1.Value, intList[1]);
+        }
+
+        if (intList.Count > 2 && nr2.HasValue)
+        {
+            Assert.Equal(nr2.Value, intList[2]);
+        }
+
+        if (intList.Count > 3 && nr3.HasValue)
+        {
+            Assert.Equal(nr3.Value, intList[3]);
+        }
+
+        if (intList.Count > 4 && nr4.HasValue)
+        {
+            Assert.Equal(nr4.Value, intList[4]);
+        }
+    }
+}

--- a/Test_xUnit/NamedCollections/TestDictionaryOfNamedCollection.cs
+++ b/Test_xUnit/NamedCollections/TestDictionaryOfNamedCollection.cs
@@ -14,15 +14,19 @@
 //    limitations under the License.
 
 using System;
+using System.IO;
 using System.Linq;
 using ahbsd.lib;
+using ahbsd.lib.Interfaces;
 using ahbsd.lib.NamedCollections;
+using ahbsd.lib.Tools;
 using Xunit;
 
 namespace Test_xUnit.NamedCollections
 {
     public class TestDictionaryOfNamedCollection
     {
+        private static readonly ILogger TestLogger = new Logger($"{Path.GetTempPath()}Test.log");
 #pragma warning disable S4143
         [Fact]
         public void TestDictionaryOfNamedCollections()
@@ -46,14 +50,12 @@ namespace Test_xUnit.NamedCollections
 
         private void D2_OnNamedCollectionAdded(object sender, EventArgs<INamedCollection<string>> e)
         {
-            Console.WriteLine("To {0} a new INamedCollection<string> was added:", sender);
-            Console.WriteLine(e.Value);
+            TestLogger.Log($"To {sender.ToString()} a new INamedCollection<string> was added: {e.Value}");
         }
 
         private void D1_OnNamedCollectionAdded(object sender, EventArgs<INamedCollection<double>> e)
         {
-            Console.WriteLine("To {0} a new INamedCollection<double> was added:", sender);
-            Console.WriteLine(e.Value);
+            TestLogger.Log($"To {sender.ToString()} a new INamedCollection<double> was added: {e.Value}");
         }
 
         [Fact]
@@ -77,6 +79,7 @@ namespace Test_xUnit.NamedCollections
             l1.Add(2, 1.3);
 
             l2.Add("Apple", "iPhone X", "Apple Devices");
+            l2.Add("Apple", "iPhone 13");
             l2.Add("Apple", "iPad");
             l2.Add("Amazon", "Echo", "Amazon Devices");
         }
@@ -84,29 +87,13 @@ namespace Test_xUnit.NamedCollections
         private void L1_OnNamedListAdded(object sender, EventArgs<INamedList<double>> e)
         {
             Assert.IsType<double>(e.Value.LastOrDefault());
-            Console.WriteLine("To {0} a new INamedList<double> was added:", sender);
-            Console.WriteLine(e.Value);
+            TestLogger.Log($"To {sender} a new INamedList<double> was added: {e.Value}");
         }
 
         private void L2_OnNamedListAdded(object sender, EventArgs<INamedList<string>> e)
         {
-            if (e.Value.Count > 0)
-            {
-                Assert.IsType<string>(e.Value.LastOrDefault());
-            }
-            else
-            {
-                try
-                {
-                    Assert.IsType<string[]>(e.Value.ToArray());
-                }
-                catch (Exception)
-                {
-                    //
-                }
-            }
-            Console.WriteLine("To {0} a new INamedList<string> was added:", sender);
-            Console.WriteLine(e.Value);
+            Assert.IsType<string[]>(e.Value.ToArray());
+            TestLogger.Log($"To {sender} a new INamedList<string> was added: {e.Value}");
         }
 #pragma warning restore S4143
     }

--- a/Test_xUnit/NamedCollections/TestNamedCollections.cs
+++ b/Test_xUnit/NamedCollections/TestNamedCollections.cs
@@ -14,15 +14,18 @@
 //    limitations under the License.
 
 using System;
+using System.IO;
 using ahbsd.lib.EventArgs;
+using ahbsd.lib.Interfaces;
 using ahbsd.lib.NamedCollections;
+using ahbsd.lib.Tools;
 using Xunit;
 
 namespace Test_xUnit.NamedCollections
 {
     public class TestNamedCollections
     {
-
+        private static readonly ILogger TestLogger = new Logger($"{Path.GetTempPath()}Test.log");
 
         [Fact]
         public void TestNamedCollection()
@@ -33,8 +36,8 @@ namespace Test_xUnit.NamedCollections
             l1.OnNameChanged += Nc1_OnNameChanged;
 
 
-            Console.WriteLine(nc1);
-            Console.WriteLine(l1);
+            TestLogger.Log(nc1);
+            TestLogger.Log(l1);
 
             l1.Name = "Named List #1";
 
@@ -46,8 +49,8 @@ namespace Test_xUnit.NamedCollections
             nc1.Name = "NamedCollection 1";
             nc1.Name = "Collection 1, which is named.";
 
-            Console.WriteLine(nc1);
-            Console.WriteLine(l1);
+            TestLogger.Log(nc1);
+            TestLogger.Log(l1);
             
             Assert.True(true);
         }
@@ -55,11 +58,8 @@ namespace Test_xUnit.NamedCollections
 
         private void Nc1_OnNameChanged(object sender, ChangeEventArgs<string> e)
         {
-            Console.WriteLine("The named collections name has changed");
-            Console.WriteLine("The sending object was {0}", sender);
-            Console.WriteLine(e.ToString());
-            Console.WriteLine();
-
+            TestLogger.Log($"The named collections name has changed: The sending object was {sender.ToString()} ChangeEventArgs<string>: {e}");
+            Assert.NotEqual(e.OldValue, e.NewValue);
         }
     }
 }

--- a/Test_xUnit/TestChanged.cs
+++ b/Test_xUnit/TestChanged.cs
@@ -1,61 +1,69 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using ahbsd.lib.EventArgs;
 using ahbsd.lib.Exceptions;
+using ahbsd.lib.Interfaces;
+using ahbsd.lib.Tools;
 using Xunit;
 
 namespace Test_xUnit
 {
     public class TestChanged
     {
-        private static int nr;
+        private static int _nr;
         private readonly IDictionary<int, int?> apiKeys = new Dictionary<int, int?>();
-
+        private static readonly ILogger TestLogger = new Logger($"{Path.GetTempPath()}Test.log");
 
         [Theory]
         [InlineData(null, 1.0)]
-        [InlineData(0, 1.0)]
+        [InlineData(0d, 1.0)]
         [InlineData(3.14, 3.1415)]
         [InlineData(Math.PI, 3.14)]
         public void OnChangedTest(double? oldValue, double? newValue)
         {
-            ITestClass<double?> testClass = new TestClass<double?, string>(oldValue, $"TC{nr}");
-            apiKeys.Add(nr, TestClass<double?, string>.FindApiKey($"TC{nr}"));
+            TestLogger.Log($"Starting Theory {GetType().Name}.OnChangedTest(oldValue: {oldValue}, newValue: {newValue}");
+            ITestClass<double?> testClass = new TestClass<double?, string>(oldValue, $"TC{_nr}");
+            apiKeys.Add(_nr, TestClass<double?, string>.FindApiKey($"TC{_nr}"));
             testClass.OnChange += TestClass_OnChange;
             testClass.Variable = newValue;
             Assert.NotEqual(oldValue, testClass.Variable);
-            nr++;
+            _nr++;
+            
+            TestLogger.Log($"Stopped Theory {GetType().Name}.OnChangedTest(oldValue: {oldValue}, newValue: {newValue}");
         }
 
         private void TestClass_OnChange(object sender, ChangeEventArgs<double?> e)
         {
-            TestClass<double?, string> castedSender = (TestClass<double?, string>)sender;
-            string apiKey = null;
-
-            if (apiKeys[nr].HasValue)
+            if (sender is TestClass<double?, string> castedSender)
             {
-                apiKey = TestClass<double?, string>.GetApiKey(apiKeys[nr].Value);
-            }
+                string apiKey = null;
 
-            try
-            {
-                Assert.NotEqual(e.OldValue, e.NewValue);
-                Assert.Equal(e.NewValue, castedSender.Variable);
-                if (apiKeys[nr].HasValue)
+                if (apiKeys[_nr].HasValue)
                 {
-                    Assert.Equal(apiKey, $"TC{nr}");
+                    apiKey = TestClass<double?, string>.GetApiKey(apiKeys[_nr].Value);
                 }
-            }
-            catch (Exception ex2)
-            {
-                Console.WriteLine($"A {ex2.GetType()} happened:");
-                Console.WriteLine($"Message: {ex2.Message}");
+
+                try
+                {
+                    Assert.NotEqual(e.OldValue, e.NewValue);
+                    Assert.Equal(e.NewValue, castedSender.Variable);
+                    if (apiKeys[_nr].HasValue)
+                    {
+                        Assert.Equal(apiKey, $"TC{_nr}");
+                    }
+                }
+                catch (Exception ex2)
+                {
+                    TestLogger.Log(ex2);
+                }
             }
         }
 
         [Fact]
         public void TestChange()
         {
+            TestLogger.Log($"Starting Fact {GetType().Name}.TestChange");
             ITestClass<string> t1 = new TestClass<string, object>("Hello", null);
             
             ITestClass<object> t2 = new TestClass<object, string>("Hello", "A100002");
@@ -79,7 +87,10 @@ namespace Test_xUnit
             {
 #pragma warning disable S1854
                 // here we need it explicitly due to generate an exception.
+                // ReSharper disable once NotAccessedVariable
+                // ReSharper disable once PossibleInvalidCastException
                 double d = (double)t3.Variable;
+                // ReSharper disable once RedundantAssignment
                 d *= (double)t2.Variable;
 #pragma warning restore S1854
             }
@@ -88,15 +99,14 @@ namespace Test_xUnit
                 IGenericException<ITestClass<object>> exT3 = new Exception<ITestClass<object>>(ex.Message, t3, ex);
                 Assert.IsType<Exception<ITestClass<object>>>(exT3);
             }
+            
+            TestLogger.Log($"Stopped Fact {GetType().Name}.TestChange");
         }
 
         private void T3_OnChange(object sender, ChangeEventArgs<object> e)
         {
-            Console.WriteLine("The variable from 't3' has changed:");
-            Console.WriteLine("The sending object was: {0}", sender);
-            Console.WriteLine(e.ToString());
+            TestLogger.Log(GetMessage("t3", sender, e));
             Assert.NotEqual(e.OldValue, e.NewValue);
-            Console.WriteLine();
         }
 
         /// <summary>
@@ -106,11 +116,8 @@ namespace Test_xUnit
         /// <param name="e">Event Arguments.</param>
         private void T2_OnChange(object sender, ChangeEventArgs<object> e)
         {
-            Console.WriteLine("The variable from 't2' has changed:");
-            Console.WriteLine("The sending object was: {0}", sender);
-            Console.WriteLine(e.ToString());
+            TestLogger.Log(GetMessage("t2", sender, e));
             Assert.NotEqual(e.OldValue, e.NewValue);
-            Console.WriteLine();
         }
 
         /// <summary>
@@ -120,11 +127,11 @@ namespace Test_xUnit
         /// <param name="e">Event Arguments.</param>
         private void T1_OnChange(object sender, ChangeEventArgs<string> e)
         {
-            Console.WriteLine("The variable from 't1' has changed:");
-            Console.WriteLine("The sending object was: {0}", sender);
-            Console.WriteLine(e.ToString());
+            TestLogger.Log(GetMessage("t1", sender, e));
             Assert.NotEqual(e.OldValue, e.NewValue);
-            Console.WriteLine();
         }
+
+        private static string GetMessage<T>(string valueName, object sender, ChangeEventArgs<T> e)
+            => $"The variable from '{valueName}' has changed: The sending object was: {sender.ToString()}, ChangeEventArgs: {e}";
     }
 }

--- a/Test_xUnit/Test_xUnit.csproj
+++ b/Test_xUnit/Test_xUnit.csproj
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="coverlet.collector" Version="3.2.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
   </ItemGroup>

--- a/Test_xUnit/Test_xUnit.csproj
+++ b/Test_xUnit/Test_xUnit.csproj
@@ -5,7 +5,7 @@
 
     <IsPackable>false</IsPackable>
     <ReleaseVersion>1.0.0</ReleaseVersion>
-    <LangVersion>latestmajor</LangVersion>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ahbsd.lib/ApiKey/ApiKeyHolder.static.cs
+++ b/ahbsd.lib/ApiKey/ApiKeyHolder.static.cs
@@ -42,14 +42,11 @@ public partial class ApiKeyHolder<T> : ApiKeyHolderBase<T>
     /// <param name="apiKey">New API-Key</param>
     protected internal static void AddApiKey(object sender, T apiKey)
     {
-        ApiKeyEventArgs<T> e;
-        int idx;
-
         if (!KnownApiKeys.Contains(apiKey))
         {
             KnownApiKeys.Add(apiKey);
-            idx = KnownApiKeys.IndexOf(apiKey);
-            e = new ApiKeyEventArgs<T>(apiKey, idx);
+            var idx = KnownApiKeys.IndexOf(apiKey);
+            var e = new ApiKeyEventArgs<T>(apiKey, idx);
             OnApiKeyAdded?.Invoke(sender, e);
         }
     }

--- a/ahbsd.lib/ApiKey/ApiKeyHolder.static.cs
+++ b/ahbsd.lib/ApiKey/ApiKeyHolder.static.cs
@@ -20,34 +20,35 @@
 
 using System.Collections.Generic;
 
-namespace ahbsd.lib.ApiKey;
-
-public partial class ApiKeyHolder<T> : ApiKeyHolderBase<T>
+namespace ahbsd.lib.ApiKey
 {
-    /// <summary>
-    /// A list of all known API-Keys.
-    /// </summary>
-    /// <remarks>Of current instances. Is eg needed for construction without api-key etc.</remarks>
-    internal static readonly List<T> KnownApiKeys = new();
-
-    /// <summary>
-    /// Happens if a new API-Key was added to the static list <see cref="KnownApiKeys"/>.
-    /// </summary>
-    public new static event ApiKeyEventHandler<T> OnApiKeyAdded;
-
-    /// <summary>
-    /// Functionality when a new API-Key was added.
-    /// </summary>
-    /// <param name="sender">Sending Object</param>
-    /// <param name="apiKey">New API-Key</param>
-    protected internal static void AddApiKey(object sender, T apiKey)
+    public partial class ApiKeyHolder<T> : ApiKeyHolderBase<T>
     {
-        if (!KnownApiKeys.Contains(apiKey))
+        /// <summary>
+        /// A list of all known API-Keys.
+        /// </summary>
+        /// <remarks>Of current instances. Is eg needed for construction without api-key etc.</remarks>
+        internal static readonly List<T> KnownApiKeys = new List<T>();
+
+        /// <summary>
+        /// Happens if a new API-Key was added to the static list <see cref="KnownApiKeys"/>.
+        /// </summary>
+        public new static event ApiKeyEventHandler<T> OnApiKeyAdded;
+
+        /// <summary>
+        /// Functionality when a new API-Key was added.
+        /// </summary>
+        /// <param name="sender">Sending Object</param>
+        /// <param name="apiKey">New API-Key</param>
+        protected internal static void AddApiKey(object sender, T apiKey)
         {
-            KnownApiKeys.Add(apiKey);
-            var idx = KnownApiKeys.IndexOf(apiKey);
-            var e = new ApiKeyEventArgs<T>(apiKey, idx);
-            OnApiKeyAdded?.Invoke(sender, e);
+            if (!KnownApiKeys.Contains(apiKey))
+            {
+                KnownApiKeys.Add(apiKey);
+                var idx = KnownApiKeys.IndexOf(apiKey);
+                var e = new ApiKeyEventArgs<T>(apiKey, idx);
+                OnApiKeyAdded?.Invoke(sender, e);
+            }
         }
     }
 }

--- a/ahbsd.lib/ApiKey/ApiKeyHolderBase.cs
+++ b/ahbsd.lib/ApiKey/ApiKeyHolderBase.cs
@@ -95,10 +95,7 @@ public abstract class ApiKeyHolderBase<T> : IEqualityComparer<T>
            || obj is ApiKeyHolder<T> other 
            && Equals(other);
 
-    /// <summary>
-    /// Gets a string that describes the current ApiKey.
-    /// </summary>
-    /// <returns>A string that describes the current ApiKey</returns>
+    /// <inheritdoc/>
     public override string ToString() => $"{nameof(ApiKey)} ({typeof(T).Name}): {ApiKey}";
 
     /// <inheritdoc/>

--- a/ahbsd.lib/ApiKey/ApiKeyHolderBase.cs
+++ b/ahbsd.lib/ApiKey/ApiKeyHolderBase.cs
@@ -22,115 +22,116 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace ahbsd.lib.ApiKey;
-
-/// <summary>
-/// The abstract base for API Key Holder
-/// </summary>
-/// <typeparam name="T">The Type of the API Key</typeparam>
-public abstract class ApiKeyHolderBase<T> : IEqualityComparer<T>
+namespace ahbsd.lib.ApiKey
 {
     /// <summary>
-    /// An equality comparer.
+    /// The abstract base for API Key Holder
     /// </summary>
-    private readonly IEqualityComparer<T> equalityComparerImplementation;
-
-    /// <summary>
-    /// Constructor with a given API-Key.
-    /// </summary>
-    /// <param name="apiKey">The API-Key.</param>
-    protected ApiKeyHolderBase(T apiKey)
+    /// <typeparam name="T">The Type of the API Key</typeparam>
+    public abstract class ApiKeyHolderBase<T> : IEqualityComparer<T>
     {
-        ApiKeyHolder<T>.OnApiKeyAdded += ApiKeyHolder_OnApiKeyAdded;
-        ApiKey = apiKey;
-        equalityComparerImplementation = new ApiKeyHolder<T>();
-        ApiKeyHolder<T>.AddApiKey(this, apiKey);
-    }
+        /// <summary>
+        /// An equality comparer.
+        /// </summary>
+        private readonly IEqualityComparer<T> equalityComparerImplementation;
 
-    /// <summary>
-    /// Constructor without parameters.
-    /// </summary>
-    /// <remarks>If before an object was created, the last API-Key will be used. Otherwise the <c>default of T will be used.</c></remarks>
-    /// <exception cref="ArgumentNullException">If <see cref="ApiKeyHolder{T}.KnownApiKeys"/> is <c>null</c> or something similar.</exception>
-    /// <exception cref="InvalidOperationException">If anything regarding <see cref="ApiKeyHolder{T}.KnownApiKeys"/> is an invalid operation.</exception>
-    protected ApiKeyHolderBase()
-    {
-        ApiKeyHolder<T>.OnApiKeyAdded += ApiKeyHolder_OnApiKeyAdded;
-        ApiKey = ApiKeyHolder<T>.KnownApiKeys.Count > 0 ? ApiKeyHolder<T>.KnownApiKeys.Last() : default;
-        ApiKeyHolder<T>.AddApiKey(this, ApiKey);
-    }
-
-    /// <summary>
-    /// If an <see cref="ApiKey"/> was added to <see cref="ApiKeyHolder{T}"/>
-    /// </summary>
-    /// <param name="sender">The sending object</param>
-    /// <param name="e">The event arguments</param>
-    private void ApiKeyHolder_OnApiKeyAdded(object sender, ApiKeyEventArgs<T> e)
-    {
-        OnApiKeyAdded?.Invoke(sender, e);
-    }
-
-    /// <summary>
-    /// Gets the API-Key.
-    /// </summary>
-    /// <value>The API-Key.</value>
-    internal T ApiKey { get; }
-
-    /// <inheritdoc/>
-    public override int GetHashCode() => EqualityComparer<T>.Default.GetHashCode(ApiKey);
-
-    /// <summary>
-    /// Determines whether the given other equals this object.
-    /// </summary>
-    /// <param name="other">The other object</param>
-    /// <returns>Is the other object equal to this?</returns>
-    private bool Equals(ApiKeyHolderBase<T> other) 
-        => !ReferenceEquals(null, other) 
-           && (ReferenceEquals(this, other) 
-               || EqualityComparer<T>.Default.Equals(ApiKey, other.ApiKey));
-
-    /// <inheritdoc/>
-    public override bool Equals(object obj) 
-        => ReferenceEquals(this, obj) 
-           || obj is ApiKeyHolder<T> other 
-           && Equals(other);
-
-    /// <inheritdoc/>
-    public override string ToString() => $"{nameof(ApiKey)} ({typeof(T).Name}): {ApiKey}";
-
-    /// <inheritdoc/>
-    public bool Equals(T x, T y) => equalityComparerImplementation.Equals(x, y);
-
-    /// <inheritdoc cref="GetHashCode()"/>
-    public int GetHashCode(T obj) => equalityComparerImplementation.GetHashCode(obj);
-
-    /// <summary>
-    /// Happens if a new API-Key was added to the static list <see cref="ApiKeyHolder{T}.KnownApiKeys"/>.
-    /// </summary>
-    public event ApiKeyEventHandler<T> OnApiKeyAdded;
-
-    /// <summary>
-    /// Looks for a given API-Key.
-    /// </summary>
-    /// <param name="apiKey">The given API-Key.</param>
-    /// <returns>If found it returns the index, if not <c>null</c> is returned.</returns>
-    public static int? FindApiKey(T apiKey)
-    {
-        int? result = null;
-
-        if (ApiKeyHolder<T>.KnownApiKeys.Contains(apiKey))
+        /// <summary>
+        /// Constructor with a given API-Key.
+        /// </summary>
+        /// <param name="apiKey">The API-Key.</param>
+        protected ApiKeyHolderBase(T apiKey)
         {
-            result = ApiKeyHolder<T>.KnownApiKeys.IndexOf(apiKey);
+            ApiKeyHolder<T>.OnApiKeyAdded += ApiKeyHolder_OnApiKeyAdded;
+            ApiKey = apiKey;
+            equalityComparerImplementation = new ApiKeyHolder<T>();
+            ApiKeyHolder<T>.AddApiKey(this, apiKey);
         }
 
-        return result;
+        /// <summary>
+        /// Constructor without parameters.
+        /// </summary>
+        /// <remarks>If before an object was created, the last API-Key will be used. Otherwise the <c>default of T will be used.</c></remarks>
+        /// <exception cref="ArgumentNullException">If <see cref="ApiKeyHolder{T}.KnownApiKeys"/> is <c>null</c> or something similar.</exception>
+        /// <exception cref="InvalidOperationException">If anything regarding <see cref="ApiKeyHolder{T}.KnownApiKeys"/> is an invalid operation.</exception>
+        protected ApiKeyHolderBase()
+        {
+            ApiKeyHolder<T>.OnApiKeyAdded += ApiKeyHolder_OnApiKeyAdded;
+            ApiKey = ApiKeyHolder<T>.KnownApiKeys.Count > 0 ? ApiKeyHolder<T>.KnownApiKeys.Last() : default;
+            ApiKeyHolder<T>.AddApiKey(this, ApiKey);
+        }
+
+        /// <summary>
+        /// If an <see cref="ApiKey"/> was added to <see cref="ApiKeyHolder{T}"/>
+        /// </summary>
+        /// <param name="sender">The sending object</param>
+        /// <param name="e">The event arguments</param>
+        private void ApiKeyHolder_OnApiKeyAdded(object sender, ApiKeyEventArgs<T> e)
+        {
+            OnApiKeyAdded?.Invoke(sender, e);
+        }
+
+        /// <summary>
+        /// Gets the API-Key.
+        /// </summary>
+        /// <value>The API-Key.</value>
+        internal T ApiKey { get; }
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => EqualityComparer<T>.Default.GetHashCode(ApiKey);
+
+        /// <summary>
+        /// Determines whether the given other equals this object.
+        /// </summary>
+        /// <param name="other">The other object</param>
+        /// <returns>Is the other object equal to this?</returns>
+        private bool Equals(ApiKeyHolderBase<T> other) 
+            => !ReferenceEquals(null, other) 
+               && (ReferenceEquals(this, other) 
+                   || EqualityComparer<T>.Default.Equals(ApiKey, other.ApiKey));
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj) 
+            => ReferenceEquals(this, obj) 
+               || obj is ApiKeyHolder<T> other 
+               && Equals(other);
+
+        /// <inheritdoc/>
+        public override string ToString() => $"{nameof(ApiKey)} ({typeof(T).Name}): {ApiKey}";
+
+        /// <inheritdoc/>
+        public bool Equals(T x, T y) => equalityComparerImplementation.Equals(x, y);
+
+        /// <inheritdoc cref="GetHashCode()"/>
+        public int GetHashCode(T obj) => equalityComparerImplementation.GetHashCode(obj);
+
+        /// <summary>
+        /// Happens if a new API-Key was added to the static list <see cref="ApiKeyHolder{T}.KnownApiKeys"/>.
+        /// </summary>
+        public event ApiKeyEventHandler<T> OnApiKeyAdded;
+
+        /// <summary>
+        /// Looks for a given API-Key.
+        /// </summary>
+        /// <param name="apiKey">The given API-Key.</param>
+        /// <returns>If found it returns the index, if not <c>null</c> is returned.</returns>
+        public static int? FindApiKey(T apiKey)
+        {
+            int? result = null;
+
+            if (ApiKeyHolder<T>.KnownApiKeys.Contains(apiKey))
+            {
+                result = ApiKeyHolder<T>.KnownApiKeys.IndexOf(apiKey);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Returns an API-Key from a defined index number.
+        /// </summary>
+        /// <param name="idx">The defined index number.</param>
+        /// <returns>An API-Key.</returns>
+        public static T GetApiKey(int idx) => ApiKeyHolder<T>.KnownApiKeys[idx];
+
     }
-
-    /// <summary>
-    /// Returns an API-Key from a defined index number.
-    /// </summary>
-    /// <param name="idx">The defined index number.</param>
-    /// <returns>An API-Key.</returns>
-    public static T GetApiKey(int idx) => ApiKeyHolder<T>.KnownApiKeys[idx];
-
 }

--- a/ahbsd.lib/Attributes/static.ApiAttribute.cs
+++ b/ahbsd.lib/Attributes/static.ApiAttribute.cs
@@ -21,22 +21,23 @@
 using System;
 using System.Collections.Generic;
 
-namespace ahbsd.lib.Attributes;
-
-/// <summary>
-/// Attribute that tells, that this belongs to the API.
-/// </summary>
-partial class ApiAttribute : Attribute
+namespace ahbsd.lib.Attributes
 {
     /// <summary>
-    /// A collection of types, that are using this <see cref="Attribute"/>.
+    /// Attribute that tells, that this belongs to the API.
     /// </summary>
-    private static readonly ICollection<Type> usingTypes = new List<Type>();
+    partial class ApiAttribute : Attribute
+    {
+        /// <summary>
+        /// A collection of types, that are using this <see cref="Attribute"/>.
+        /// </summary>
+        private static readonly ICollection<Type> usingTypes = new List<Type>();
 
 
-    /// <summary>
-    /// Gets all <see cref="Type"/>s, that use this Attribute.
-    /// </summary>
-    /// <value>All <see cref="Type"/>s, that use this Attribute</value>
-    public static IReadOnlyCollection<Type> UsingTypes => (IReadOnlyCollection<Type>) usingTypes;
+        /// <summary>
+        /// Gets all <see cref="Type"/>s, that use this Attribute.
+        /// </summary>
+        /// <value>All <see cref="Type"/>s, that use this Attribute</value>
+        public static IReadOnlyCollection<Type> UsingTypes => (IReadOnlyCollection<Type>) usingTypes;
+    }
 }

--- a/ahbsd.lib/Collections/SourceDirectories.cs
+++ b/ahbsd.lib/Collections/SourceDirectories.cs
@@ -22,6 +22,7 @@ using System.Collections;
 using System.Collections.Generic;
 using ahbsd.lib.EventArgs;
 using ahbsd.lib.EventHandler;
+using ahbsd.lib.Extensions;
 using ahbsd.lib.Interfaces;
 
 namespace ahbsd.lib.Collections;
@@ -61,7 +62,7 @@ public class SourceDirectories : ISourceDirectories
     /// <inheritdoc/>
     public void Add(string item)
     {
-        if (!string.IsNullOrWhiteSpace(item))
+        if (!item.IsNullOrWhiteSpace())
         {
             CollectionAddEventArgs<string> addEventArgs = new(this, item);
             innerCollection.Add(item);

--- a/ahbsd.lib/Collections/SourceDirectories.cs
+++ b/ahbsd.lib/Collections/SourceDirectories.cs
@@ -25,72 +25,73 @@ using ahbsd.lib.EventHandler;
 using ahbsd.lib.Extensions;
 using ahbsd.lib.Interfaces;
 
-namespace ahbsd.lib.Collections;
-
-/// <summary>
-/// Class for source directories.
-/// </summary>
-public class SourceDirectories : ISourceDirectories
+namespace ahbsd.lib.Collections
 {
-    private readonly ICollection<string> innerCollection;
-
     /// <summary>
-    /// Simple constructor.
+    /// Class for source directories.
     /// </summary>
-    public SourceDirectories() => innerCollection = new List<string>();
+    public class SourceDirectories : ISourceDirectories
+    {
+        private readonly ICollection<string> innerCollection;
 
-    /// <summary>
-    /// Constructor with a base capacity.
-    /// </summary>
-    /// <param name="capacity">Base capacity</param>
-    public SourceDirectories(int capacity) => innerCollection = new List<string>(capacity);
+        /// <summary>
+        /// Simple constructor.
+        /// </summary>
+        public SourceDirectories() => innerCollection = new List<string>();
 
-    #region implementation of ISourceDirectories
+        /// <summary>
+        /// Constructor with a base capacity.
+        /// </summary>
+        /// <param name="capacity">Base capacity</param>
+        public SourceDirectories(int capacity) => innerCollection = new List<string>(capacity);
+
+        #region implementation of ISourceDirectories
     
 #pragma warning disable S3264
-    // Quite unsure, why Sonar doesn't see the use of this event...
-    /// <inheritdoc/>
-    public event CollectionAddEventHandler<string> OnNewDirectoryAdded;
+        // Quite unsure, why Sonar doesn't see the use of this event...
+        /// <inheritdoc/>
+        public event CollectionAddEventHandler<string> OnNewDirectoryAdded;
 #pragma warning restore S3264
     
-    /// <inheritdoc/>
-    public IEnumerator<string> GetEnumerator() => innerCollection.GetEnumerator();
+        /// <inheritdoc/>
+        public IEnumerator<string> GetEnumerator() => innerCollection.GetEnumerator();
 
-    /// <inheritdoc/>
-    IEnumerator IEnumerable.GetEnumerator() => (innerCollection as IEnumerable).GetEnumerator();
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator() => (innerCollection as IEnumerable).GetEnumerator();
 
-    /// <inheritdoc/>
-    public void Add(string item)
-    {
-        if (!item.IsNullOrWhiteSpace())
+        /// <inheritdoc/>
+        public void Add(string item)
         {
-            CollectionAddEventArgs<string> addEventArgs = new(this, item);
-            innerCollection.Add(item);
-            OnNewDirectoryAdded?.Invoke(this, addEventArgs);
+            if (!item.IsNullOrWhiteSpace())
+            {
+                CollectionAddEventArgs<string> addEventArgs = new CollectionAddEventArgs<string>(this, item);
+                innerCollection.Add(item);
+                OnNewDirectoryAdded?.Invoke(this, addEventArgs);
+            }
         }
+
+        /// <inheritdoc/>
+        public void Clear() => innerCollection.Clear();
+
+        /// <inheritdoc/>
+        public bool Contains(string item) => innerCollection.Contains(item);
+
+        /// <inheritdoc/>
+        public void CopyTo(string[] array, int arrayIndex) => innerCollection.CopyTo(array, arrayIndex);
+
+        /// <inheritdoc/>
+        public bool Remove(string item) => innerCollection.Remove(item);
+
+        /// <inheritdoc/>
+        public int Count => innerCollection.Count;
+
+        /// <inheritdoc/>
+        public bool IsReadOnly => innerCollection.IsReadOnly;
+
+        /// <inheritdoc/>
+        public IReadOnlyCollection<string> AsReadonly => (IReadOnlyCollection<string>) innerCollection;
+
+        #endregion
+
     }
-
-    /// <inheritdoc/>
-    public void Clear() => innerCollection.Clear();
-
-    /// <inheritdoc/>
-    public bool Contains(string item) => innerCollection.Contains(item);
-
-    /// <inheritdoc/>
-    public void CopyTo(string[] array, int arrayIndex) => innerCollection.CopyTo(array, arrayIndex);
-
-    /// <inheritdoc/>
-    public bool Remove(string item) => innerCollection.Remove(item);
-
-    /// <inheritdoc/>
-    public int Count => innerCollection.Count;
-
-    /// <inheritdoc/>
-    public bool IsReadOnly => innerCollection.IsReadOnly;
-
-    /// <inheritdoc/>
-    public IReadOnlyCollection<string> AsReadonly => (IReadOnlyCollection<string>) innerCollection;
-
-    #endregion
-
 }

--- a/ahbsd.lib/Components/LoggerComponent.cs
+++ b/ahbsd.lib/Components/LoggerComponent.cs
@@ -24,6 +24,7 @@ using System.ComponentModel;
 using System.IO;
 using ahbsd.lib.EventArgs;
 using ahbsd.lib.EventHandler;
+using ahbsd.lib.Extensions;
 using ahbsd.lib.Interfaces;
 using ahbsd.lib.Tools;
 
@@ -128,7 +129,7 @@ public class LoggerComponent : Component, ILogger
         Exception maybeException = null;
         
         // if we have a previous log, we should dispose it.
-        if (!string.IsNullOrWhiteSpace(e.OldValue) && logWriter != null)
+        if (!e.OldValue.IsNullOrWhiteSpace() && logWriter != null)
         {
             try
             {
@@ -152,7 +153,7 @@ public class LoggerComponent : Component, ILogger
             }
         }
         
-        if (!string.IsNullOrWhiteSpace(e.NewValue))
+        if (!e.NewValue.IsNullOrWhiteSpace())
         {
             logWriter = File.AppendText(e.NewValue);
             disposables.Add(logWriter);
@@ -192,7 +193,7 @@ public class LoggerComponent : Component, ILogger
         {
             ChangeEventArgs<string> changeEventArgs = new(logfilePath, value);
 
-            if (!string.IsNullOrWhiteSpace(value) && !value.Equals(logfilePath))
+            if (!value.IsNullOrWhiteSpace() && !value.Equals(logfilePath))
             {
                 logfilePath = value;
                 OnLogfileChanged?.Invoke(this, changeEventArgs);

--- a/ahbsd.lib/Components/LoggerComponent.cs
+++ b/ahbsd.lib/Components/LoggerComponent.cs
@@ -155,18 +155,27 @@ public class LoggerComponent : Component, ILogger
         
         if (!e.NewValue.IsNullOrWhiteSpace())
         {
-            logWriter = File.AppendText(e.NewValue);
-            disposables.Add(logWriter);
-            logWriter.AutoFlush = true;
-            isDisposed = false;
+            try
+            {
+                logWriter = File.AppendText(e.NewValue);
+                disposables.Add(logWriter);
+                logWriter.AutoFlush = true;
+                isDisposed = false;
 
-            var filename = Logger.GetFilename(e.NewValue, out var alreadyExists);
+                var filename = Logger.GetFilename(e.NewValue, out var alreadyExists);
 
-            var newFile = alreadyExists ? "the existing" : "the new";
+                var newFile = alreadyExists ? "the existing" : "the new";
             
-            Log($"A new log started with {newFile} logfile '{filename}' in logger {Name}.");
+                Log($"A new log started with {newFile} logfile '{filename}' in logger {Name}.");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+                logWriter = null;
+                maybeException = ex;
+            }
 
-            if (maybeException != null)
+            if (maybeException != null && logWriter != null)
             {
                 Log(maybeException);
             }
@@ -218,6 +227,9 @@ public class LoggerComponent : Component, ILogger
     /// <inheritdoc/>
     public void Log(Exception e) 
         => logWriter?.WriteLine($"{DateTime.Now.ToUniversalTime()} – a {e.GetType().Name} happened: {e.Message}");
+
+    /// <inheritdoc />
+    public void Log(object o) => Log(o?.ToString());
     
     #endregion
 

--- a/ahbsd.lib/Components/LoggerComponent.cs
+++ b/ahbsd.lib/Components/LoggerComponent.cs
@@ -28,253 +28,254 @@ using ahbsd.lib.Extensions;
 using ahbsd.lib.Interfaces;
 using ahbsd.lib.Tools;
 
-namespace ahbsd.lib.Components;
-
-/// <summary>
-/// A logger as component.
-/// </summary>
-public class LoggerComponent : Component, ILogger
+namespace ahbsd.lib.Components
 {
     /// <summary>
-    /// Is this object already disposed?
+    /// A logger as component.
     /// </summary>
-    private bool isDisposed;
+    public class LoggerComponent : Component, ILogger
+    {
+        /// <summary>
+        /// Is this object already disposed?
+        /// </summary>
+        private bool isDisposed;
     
-    /// <summary>
-    /// The log writer.
-    /// </summary>
-    private StreamWriter logWriter;
+        /// <summary>
+        /// The log writer.
+        /// </summary>
+        private StreamWriter logWriter;
 
-    /// <summary>
-    /// The path to the logfile
-    /// </summary>
-    private string logfilePath;
+        /// <summary>
+        /// The path to the logfile
+        /// </summary>
+        private string logfilePath;
 
-    /// <summary>
-    /// The inner collection of components.
-    /// </summary>
-    private readonly ICollection<IComponent> components;
+        /// <summary>
+        /// The inner collection of components.
+        /// </summary>
+        private readonly ICollection<IComponent> components;
 
-    /// <summary>
-    /// The inner list of disposable objects.
-    /// </summary>
-    private readonly ICollection<IDisposable> disposables;
+        /// <summary>
+        /// The inner list of disposable objects.
+        /// </summary>
+        private readonly ICollection<IDisposable> disposables;
 
-    /// <summary>
-    /// Simple logger constructor.
-    /// </summary>
-    public LoggerComponent()
-    {
-        isDisposed = true; // we have not yet anything to dispose
-        components = new List<IComponent>();
-        disposables = new List<IDisposable>();
-        
-        OnLogfileChanged += This_OnLogfileChanged;
-
-        Name = GetType().Name;
-        
-        Initialize();
-    }
-
-    /// <summary>
-    /// Constructor with a given container and optional a name.
-    /// </summary>
-    /// <param name="container">The container</param>
-    /// <param name="name">[optional] The name</param>
-    public LoggerComponent(IContainer container, string name = null)
-    {
-        isDisposed = true; // we have not yet anything to dispose
-        components = new List<IComponent>();
-        disposables = new List<IDisposable>();
-        
-        OnLogfileChanged += This_OnLogfileChanged;
-
-        Name = name ?? GetType().Name;
-        
-        Initialize(container);
-    }
-
-    /// <summary>
-    /// Constructor with a given logfile path.
-    /// </summary>
-    /// <param name="logfilePath">The logfile path</param>
-    public LoggerComponent(string logfilePath) : this()
-    {
-        Logfile = logfilePath;
-    }
-    
-    /// <summary>
-    /// Initializes the object
-    /// </summary>
-    /// <param name="container">[optional] A container</param>
-    private void Initialize(IContainer container = null)
-    {
-        if (container != null)
+        /// <summary>
+        /// Simple logger constructor.
+        /// </summary>
+        public LoggerComponent()
         {
-            container.Add(this, Name);
+            isDisposed = true; // we have not yet anything to dispose
+            components = new List<IComponent>();
+            disposables = new List<IDisposable>();
+        
+            OnLogfileChanged += This_OnLogfileChanged;
+
+            Name = GetType().Name;
+        
+            Initialize();
         }
-        else
+
+        /// <summary>
+        /// Constructor with a given container and optional a name.
+        /// </summary>
+        /// <param name="container">The container</param>
+        /// <param name="name">[optional] The name</param>
+        public LoggerComponent(IContainer container, string name = null)
         {
-            Site?.Container?.Add(this, Name);
-        }
-    }
-    
-    /// <summary>
-    /// Event handler for the change of the logfile.
-    /// </summary>
-    /// <param name="sender">The sending object</param>
-    /// <param name="e">The change event args for the changed logfile path</param>
-    private void This_OnLogfileChanged(object sender, ChangeEventArgs<string> e)
-    {
-        Exception maybeException = null;
+            isDisposed = true; // we have not yet anything to dispose
+            components = new List<IComponent>();
+            disposables = new List<IDisposable>();
         
-        // if we have a previous log, we should dispose it.
-        if (!e.OldValue.IsNullOrWhiteSpace() && logWriter != null)
+            OnLogfileChanged += This_OnLogfileChanged;
+
+            Name = name ?? GetType().Name;
+        
+            Initialize(container);
+        }
+
+        /// <summary>
+        /// Constructor with a given logfile path.
+        /// </summary>
+        /// <param name="logfilePath">The logfile path</param>
+        public LoggerComponent(string logfilePath) : this()
         {
-            try
+            Logfile = logfilePath;
+        }
+    
+        /// <summary>
+        /// Initializes the object
+        /// </summary>
+        /// <param name="container">[optional] A container</param>
+        private void Initialize(IContainer container = null)
+        {
+            if (container != null)
             {
-                Log($"The current Log {Name} is ending and the logfile '{Logger.GetFilename(e.OldValue)}' will be closed.");
-
-                if (disposables.Contains(logWriter))
+                container.Add(this, Name);
+            }
+            else
+            {
+                Site?.Container?.Add(this, Name);
+            }
+        }
+    
+        /// <summary>
+        /// Event handler for the change of the logfile.
+        /// </summary>
+        /// <param name="sender">The sending object</param>
+        /// <param name="e">The change event args for the changed logfile path</param>
+        private void This_OnLogfileChanged(object sender, ChangeEventArgs<string> e)
+        {
+            Exception maybeException = null;
+        
+            // if we have a previous log, we should dispose it.
+            if (!e.OldValue.IsNullOrWhiteSpace() && logWriter != null)
+            {
+                try
                 {
-                    disposables.Remove(logWriter);
+                    Log($"The current Log {Name} is ending and the logfile '{Logger.GetFilename(e.OldValue)}' will be closed.");
+
+                    if (disposables.Contains(logWriter))
+                    {
+                        disposables.Remove(logWriter);
+                    }
+                    logWriter.Flush();
+                    logWriter.Close();
+                    logWriter.Dispose();
                 }
-                logWriter.Flush();
-                logWriter.Close();
-                logWriter.Dispose();
+                catch (Exception ex)
+                {
+                    maybeException = ex;
+                }
+                finally
+                {
+                    logWriter = null;
+                }
             }
-            catch (Exception ex)
-            {
-                maybeException = ex;
-            }
-            finally
-            {
-                logWriter = null;
-            }
-        }
         
-        if (!e.NewValue.IsNullOrWhiteSpace())
-        {
-            try
+            if (!e.NewValue.IsNullOrWhiteSpace())
             {
-                logWriter = File.AppendText(e.NewValue);
-                disposables.Add(logWriter);
-                logWriter.AutoFlush = true;
-                isDisposed = false;
+                try
+                {
+                    logWriter = File.AppendText(e.NewValue);
+                    disposables.Add(logWriter);
+                    logWriter.AutoFlush = true;
+                    isDisposed = false;
 
-                var filename = Logger.GetFilename(e.NewValue, out var alreadyExists);
+                    var filename = Logger.GetFilename(e.NewValue, out var alreadyExists);
 
-                var newFile = alreadyExists ? "the existing" : "the new";
+                    var newFile = alreadyExists ? "the existing" : "the new";
             
-                Log($"A new log started with {newFile} logfile '{filename}' in logger {Name}.");
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex);
-                logWriter = null;
-                maybeException = ex;
-            }
-
-            if (maybeException != null && logWriter != null)
-            {
-                Log(maybeException);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Gets a readonly collection of used components.
-    /// </summary>
-    /// <value>A readonly collection of used components</value>
-    public IReadOnlyCollection<IComponent> Components => (IReadOnlyCollection<IComponent>) components;
-
-    #region implementation of ILogger
-    
-    /// <inheritdoc/>
-    [ReadOnly(true)]
-    public string Name { get; }
-
-    /// <inheritdoc/>
-    public string Logfile
-    {
-        get => logfilePath;
-        set
-        {
-            ChangeEventArgs<string> changeEventArgs = new(logfilePath, value);
-
-            if (!value.IsNullOrWhiteSpace() && !value.Equals(logfilePath))
-            {
-                logfilePath = value;
-                OnLogfileChanged?.Invoke(this, changeEventArgs);
-            }
-            else if (value == null && logfilePath != null)
-            {
-                logfilePath = null;
-                OnLogfileChanged?.Invoke(this, changeEventArgs);
-            }
-        }
-    }
-    
-    /// <inheritdoc/>
-    public event ChangeEventHandler<string> OnLogfileChanged;
-
-    /// <inheritdoc/>
-    public void Log(string message) => logWriter?.WriteLine($"{DateTime.Now.ToUniversalTime()} – {message}");
-
-    /// <inheritdoc/>
-    public void Log(ErrorEventArgs e) => Log(e.GetException());
-
-    /// <inheritdoc/>
-    public void Log(Exception e) 
-        => logWriter?.WriteLine($"{DateTime.Now.ToUniversalTime()} – a {e.GetType().Name} happened: {e.Message}");
-
-    /// <inheritdoc />
-    public void Log(object o) => Log(o?.ToString());
-    
-    #endregion
-
-    #region implementation of IDisposable
-    /// <summary>
-    /// Releases the logfile path
-    /// </summary>
-    private void ReleaseUnmanagedResources()
-    {
-        logfilePath = null;
-    }
-
-    /// <inheritdoc/>
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing && !isDisposed)
-        {
-            foreach (var disposable in disposables)
-            {
-                if (disposable is IComponent component)
-                {
-                    components.Remove(component);
-                    Log($"Component '{component}' was removed from Components.");
+                    Log($"A new log started with {newFile} logfile '{filename}' in logger {Name}.");
                 }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex);
+                    logWriter = null;
+                    maybeException = ex;
+                }
+
+                if (maybeException != null && logWriter != null)
+                {
+                    Log(maybeException);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets a readonly collection of used components.
+        /// </summary>
+        /// <value>A readonly collection of used components</value>
+        public IReadOnlyCollection<IComponent> Components => (IReadOnlyCollection<IComponent>) components;
+
+        #region implementation of ILogger
+    
+        /// <inheritdoc/>
+        [ReadOnly(true)]
+        public string Name { get; }
+
+        /// <inheritdoc/>
+        public string Logfile
+        {
+            get => logfilePath;
+            set
+            {
+                ChangeEventArgs<string> changeEventArgs = new ChangeEventArgs<string>(logfilePath, value);
+
+                if (!value.IsNullOrWhiteSpace() && !value.Equals(logfilePath))
+                {
+                    logfilePath = value;
+                    OnLogfileChanged?.Invoke(this, changeEventArgs);
+                }
+                else if (value == null && logfilePath != null)
+                {
+                    logfilePath = null;
+                    OnLogfileChanged?.Invoke(this, changeEventArgs);
+                }
+            }
+        }
+    
+        /// <inheritdoc/>
+        public event ChangeEventHandler<string> OnLogfileChanged;
+
+        /// <inheritdoc/>
+        public void Log(string message) => logWriter?.WriteLine($"{DateTime.Now.ToUniversalTime()} – {message}");
+
+        /// <inheritdoc/>
+        public void Log(ErrorEventArgs e) => Log(e.GetException());
+
+        /// <inheritdoc/>
+        public void Log(Exception e) 
+            => logWriter?.WriteLine($"{DateTime.Now.ToUniversalTime()} – a {e.GetType().Name} happened: {e.Message}");
+
+        /// <inheritdoc />
+        public void Log(object o) => Log(o?.ToString());
+    
+        #endregion
+
+        #region implementation of IDisposable
+        /// <summary>
+        /// Releases the logfile path
+        /// </summary>
+        private void ReleaseUnmanagedResources()
+        {
+            logfilePath = null;
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !isDisposed)
+            {
+                foreach (var disposable in disposables)
+                {
+                    if (disposable is IComponent component)
+                    {
+                        components.Remove(component);
+                        Log($"Component '{component}' was removed from Components.");
+                    }
                 
-                Log($"Item '{disposable}' will be disposed");
-                disposable.Dispose();
+                    Log($"Item '{disposable}' will be disposed");
+                    disposable.Dispose();
+                }
+            
+                disposables.Clear();
+                components.Clear();
+            
+                Logfile = null;
+                isDisposed = true;
             }
-            
-            disposables.Clear();
-            components.Clear();
-            
-            Logfile = null;
-            isDisposed = true;
+        
+            base.Dispose(disposing);
+        
+            ReleaseUnmanagedResources();
         }
-        
-        base.Dispose(disposing);
-        
-        ReleaseUnmanagedResources();
-    }
 
-    /// <inheritdoc />
-    ~LoggerComponent()
-    {
-        Dispose(false);
+        /// <inheritdoc />
+        ~LoggerComponent()
+        {
+            Dispose(false);
+        }
+        #endregion
     }
-    #endregion
 }

--- a/ahbsd.lib/EventArgs/CollectionAddEventArgs.cs
+++ b/ahbsd.lib/EventArgs/CollectionAddEventArgs.cs
@@ -23,58 +23,58 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using ahbsd.lib.Interfaces;
 
-namespace ahbsd.lib.EventArgs;
-
-/// <summary>
-/// Class for generic event Args handling additions to <see cref="ICollection{T}"/>s.
-/// </summary>
-/// <typeparam name="T">The <see cref="Type"/> to use</typeparam>
-public class CollectionAddEventArgs<T> : EventArgs<T>, ICollectionAddEventArgs<T>
+namespace ahbsd.lib.EventArgs
 {
     /// <summary>
-    /// The affected collection
+    /// Class for generic event Args handling additions to <see cref="ICollection{T}"/>s.
     /// </summary>
-    private readonly ICollection<T> affectedCollection;
+    /// <typeparam name="T">The <see cref="Type"/> to use</typeparam>
+    public class CollectionAddEventArgs<T> : EventArgs<T>, ICollectionAddEventArgs<T>
+    {
+        /// <summary>
+        /// The affected collection
+        /// </summary>
+        private readonly ICollection<T> affectedCollection;
         
-    /// <summary>
-    /// Constructor with a given affected collection and the added item.
-    /// </summary>
-    /// <param name="affectedCollection">The affected collection</param>
-    /// <param name="addedItem">The added item</param>
-    public CollectionAddEventArgs([NotNull]ICollection<T> affectedCollection, [NotNull]T addedItem) 
-        : base(addedItem)
-    {
-        this.affectedCollection = affectedCollection;
-    }
+        /// <summary>
+        /// Constructor with a given affected collection and the added item.
+        /// </summary>
+        /// <param name="affectedCollection">The affected collection</param>
+        /// <param name="addedItem">The added item</param>
+        public CollectionAddEventArgs([NotNull]ICollection<T> affectedCollection, [NotNull]T addedItem) 
+            : base(addedItem) => this.affectedCollection = affectedCollection;
 
-    #region implementation of ICollectionAddEventArgs
-    /// <inheritdoc/>
-    public IReadOnlyCollection<T> AffectedCollection
-    {
-        get
+        #region implementation of ICollectionAddEventArgs
+        /// <inheritdoc/>
+        public IReadOnlyCollection<T> AffectedCollection
         {
-            IReadOnlyCollection<T> result;
+            get
+            {
+                IReadOnlyCollection<T> result;
 
-            if (typeof(T) == typeof(string) && affectedCollection is ISourceDirectories sourceDirectories)
-            {
-                result = sourceDirectories.AsReadonly as IReadOnlyCollection<T>;
-            }
-            else
-            {
-                if (affectedCollection is IAsReadonlyCollection<T> eventCollection)
+                if (typeof(T) == typeof(string) && affectedCollection is ISourceDirectories sourceDirectories)
                 {
-                    result = eventCollection.AsReadonly;
+                    result = sourceDirectories.AsReadonly as IReadOnlyCollection<T>;
                 }
                 else
                 {
-                    result = (IReadOnlyCollection<T>) affectedCollection;
+                    if (affectedCollection is IAsReadonlyCollection<T> eventCollection)
+                    {
+                        result = eventCollection.AsReadonly;
+                    }
+                    else
+                    {
+                        result = (IReadOnlyCollection<T>) affectedCollection;
+                    }
                 }
-                    
+            
+                return result;
             }
-
-            return result ??= new List<T>();
         }
-    }
 
-    #endregion
+        #endregion
+
+        /// <inheritdoc />
+        public override string ToString() => $"CollectionAddEventArgs<{typeof(T)}>, AffectedCollection.Count={affectedCollection.Count}, AffectedCollection-Type: {affectedCollection.GetType().Name}";
+    }
 }

--- a/ahbsd.lib/EventArgs/CollectionRemoveEventArgs.cs
+++ b/ahbsd.lib/EventArgs/CollectionRemoveEventArgs.cs
@@ -21,27 +21,28 @@
 using System.Collections.Generic;
 using ahbsd.lib.Interfaces;
 
-namespace ahbsd.lib.EventArgs;
-
-/// <summary>
-/// Event arguments for removed items.
-/// </summary>
-/// <typeparam name="T">The type of the removed items</typeparam>
-public class CollectionRemoveEventArgs<T> : System.EventArgs, ICollectionRemoveArgs<T>
+namespace ahbsd.lib.EventArgs
 {
     /// <summary>
-    /// Constructor with the removed items.
+    /// Event arguments for removed items.
     /// </summary>
-    /// <param name="removedItems">The removed items.</param>
-    public CollectionRemoveEventArgs(ICollection<T> removedItems)
+    /// <typeparam name="T">The type of the removed items</typeparam>
+    public class CollectionRemoveEventArgs<T> : System.EventArgs, ICollectionRemoveArgs<T>
     {
-        RemovedItems = (IReadOnlyCollection<T>) removedItems;
+        /// <summary>
+        /// Constructor with the removed items.
+        /// </summary>
+        /// <param name="removedItems">The removed items.</param>
+        public CollectionRemoveEventArgs(ICollection<T> removedItems)
+        {
+            RemovedItems = (IReadOnlyCollection<T>) removedItems;
+        }
+
+        #region implementation of ICollectionRemoveArgs<T>
+
+        /// <inheritdoc />
+        public IReadOnlyCollection<T> RemovedItems { get; }
+
+        #endregion
     }
-
-    #region implementation of ICollectionRemoveArgs<T>
-
-    /// <inheritdoc />
-    public IReadOnlyCollection<T> RemovedItems { get; }
-
-    #endregion
 }

--- a/ahbsd.lib/EventHandler/ChangeEventHandler.cs
+++ b/ahbsd.lib/EventHandler/ChangeEventHandler.cs
@@ -20,12 +20,13 @@
 
 using ahbsd.lib.EventArgs;
 
-namespace ahbsd.lib.EventHandler;
-
-/// <summary>
-/// A delegate for change events.
-/// </summary>
-/// <typeparam name="T">The type of changing values.</typeparam>
-/// <param name="sender">Sending object.</param>
-/// <param name="e">The changing EventArgs.</param>
-public delegate void ChangeEventHandler<T>(object sender, ChangeEventArgs<T> e);
+namespace ahbsd.lib.EventHandler
+{
+    /// <summary>
+    /// A delegate for change events.
+    /// </summary>
+    /// <typeparam name="T">The type of changing values.</typeparam>
+    /// <param name="sender">Sending object.</param>
+    /// <param name="e">The changing EventArgs.</param>
+    public delegate void ChangeEventHandler<T>(object sender, ChangeEventArgs<T> e);
+}

--- a/ahbsd.lib/EventHandler/CollectionAddEventHandler.cs
+++ b/ahbsd.lib/EventHandler/CollectionAddEventHandler.cs
@@ -22,10 +22,11 @@ using System;
 using System.Collections.Generic;
 using ahbsd.lib.EventArgs;
 
-namespace ahbsd.lib.EventHandler;
-
-/// <summary>
-/// EventHandler for adding values to a <see cref="ICollection{T}"/>
-/// </summary>
-/// <typeparam name="T">The <see cref="Type"/> of the collection</typeparam>
-public delegate void CollectionAddEventHandler<T>(object sender, CollectionAddEventArgs<T> e);
+namespace ahbsd.lib.EventHandler
+{
+    /// <summary>
+    /// EventHandler for adding values to a <see cref="ICollection{T}"/>
+    /// </summary>
+    /// <typeparam name="T">The <see cref="Type"/> of the collection</typeparam>
+    public delegate void CollectionAddEventHandler<T>(object sender, CollectionAddEventArgs<T> e);
+}

--- a/ahbsd.lib/EventHandler/CollectionRemoveArgsEventHandler.cs
+++ b/ahbsd.lib/EventHandler/CollectionRemoveArgsEventHandler.cs
@@ -20,10 +20,11 @@
 
 using ahbsd.lib.EventArgs;
 
-namespace ahbsd.lib.EventHandler;
-
-/// <summary>
-/// Event handler for removing items.
-/// </summary>
-/// <typeparam name="T">The type of the items</typeparam>
-public delegate void CollectionRemoveArgsEventHandler<T>(object sender, CollectionRemoveEventArgs<T> e);
+namespace ahbsd.lib.EventHandler
+{
+    /// <summary>
+    /// Event handler for removing items.
+    /// </summary>
+    /// <typeparam name="T">The type of the items</typeparam>
+    public delegate void CollectionRemoveArgsEventHandler<T>(object sender, CollectionRemoveEventArgs<T> e);
+}

--- a/ahbsd.lib/Exceptions/AlreadySetException.cs
+++ b/ahbsd.lib/Exceptions/AlreadySetException.cs
@@ -34,8 +34,7 @@ namespace ahbsd.lib.Exceptions
         /// </summary>
         /// <param name="info">The serialization info</param>
         /// <param name="context">The streaming context</param>
-        protected AlreadySetException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
+        protected AlreadySetException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
             // nothing so far
         }
@@ -71,7 +70,7 @@ namespace ahbsd.lib.Exceptions
         /// <returns>A string representating this Exception</returns>
         public override string ToString()
         {
-            StringBuilder builder = new();
+            StringBuilder builder = new StringBuilder();
             builder.AppendLine($"ChangeEventArgs<{typeof(T)}> with:");
             builder.AppendLine($"OldValue: '{ChangeEventArgs.OldValue}'");
             builder.AppendLine($"NewValue: '{ChangeEventArgs.NewValue}'");

--- a/ahbsd.lib/Extensions/StringExtensions.cs
+++ b/ahbsd.lib/Extensions/StringExtensions.cs
@@ -20,76 +20,77 @@
 
 using System.Collections.Generic;
 
-namespace ahbsd.lib.Extensions;
-
-/// <summary>
-/// A static class for extensions for the <see cref="string"/> class.
-/// </summary>
-public static class StringExtensions
+namespace ahbsd.lib.Extensions
 {
     /// <summary>
-    /// Indicates whether the specified string is <c>null</c> or an empty string ("").
+    /// A static class for extensions for the <see cref="string"/> class.
     /// </summary>
-    /// <param name="value">The string to test.</param>
-    /// <returns><c>true</c> if the value parameter is <c>null</c> or an empty string (""); otherwise, <c>false</c>.</returns>
-    public static bool IsNullOrEmpty(this string value) => string.IsNullOrEmpty(value);
-
-    /// <summary>
-    /// Indicates whether a specified string is <c>null</c>, empty, or consists only of white-space characters.
-    /// </summary>
-    /// <param name="value">The string to test.</param>
-    /// <returns><c>true</c> if the value parameter is <c>null</c> or <see cref="string.Empty"/>, or if value consists exclusively of white-space characters.</returns>
-    public static bool IsNullOrWhiteSpace(this string value) => string.IsNullOrWhiteSpace(value);
-
-    /// <summary>
-    /// Gets an integer list from a string with <paramref name="splitter"/> seperated integer values.
-    /// </summary>
-    /// <param name="value">The string with <paramref name="splitter"/> seperated integer values</param>
-    /// <param name="splitter">[optional] splitter; by default: ','</param>
-    /// <returns>If <paramref name="value"/> isn't <c>null</c>, a <see cref="IList{T}"/> of the found integer values; otherwise <c>null</c></returns>
-    /// <example>"1, 0, 88 , -11,2" would return a list with {1, 0, 88, -11, 2}</example>
-    public static IList<int> GetIntList(this string value, char splitter = ',')
+    public static class StringExtensions
     {
-        IList<int> result = null;
+        /// <summary>
+        /// Indicates whether the specified string is <c>null</c> or an empty string ("").
+        /// </summary>
+        /// <param name="value">The string to test.</param>
+        /// <returns><c>true</c> if the value parameter is <c>null</c> or an empty string (""); otherwise, <c>false</c>.</returns>
+        public static bool IsNullOrEmpty(this string value) => string.IsNullOrEmpty(value);
 
-        if (value != null)
+        /// <summary>
+        /// Indicates whether a specified string is <c>null</c>, empty, or consists only of white-space characters.
+        /// </summary>
+        /// <param name="value">The string to test.</param>
+        /// <returns><c>true</c> if the value parameter is <c>null</c> or <see cref="string.Empty"/>, or if value consists exclusively of white-space characters.</returns>
+        public static bool IsNullOrWhiteSpace(this string value) => string.IsNullOrWhiteSpace(value);
+
+        /// <summary>
+        /// Gets an integer list from a string with <paramref name="splitter"/> seperated integer values.
+        /// </summary>
+        /// <param name="value">The string with <paramref name="splitter"/> seperated integer values</param>
+        /// <param name="splitter">[optional] splitter; by default: ','</param>
+        /// <returns>If <paramref name="value"/> isn't <c>null</c>, a <see cref="IList{T}"/> of the found integer values; otherwise <c>null</c></returns>
+        /// <example>"1, 0, 88 , -11,2" would return a list with {1, 0, 88, -11, 2}</example>
+        public static IList<int> GetIntList(this string value, char splitter = ',')
         {
-            result = new List<int>();
+            IList<int> result = null;
 
-            foreach (var s in value.Split(splitter))
+            if (value != null)
             {
-                if (int.TryParse(s.Trim(), out var i))
+                result = new List<int>();
+
+                foreach (var s in value.Split(splitter))
                 {
-                    result.Add(i);
+                    if (int.TryParse(s.Trim(), out var i))
+                    {
+                        result.Add(i);
+                    }
                 }
             }
-        }
 
-        return result;
-    }
+            return result;
+        }
     
-    /// <summary>
-    /// Gets an integer dictionary from a string with <paramref name="splitter"/> seperated integer values.
-    /// The first value of the dictionary is the position.
-    /// </summary>
-    /// <param name="value">The string with <paramref name="splitter"/> seperated integer values</param>
-    /// <param name="splitter">[optional] splitter; by default: ','</param>
-    /// <returns>If <paramref name="value"/> isn't <c>null</c>, a <see cref="IDictionary{TKey,TValue}"/> of the found integer values; otherwise <c>null</c></returns>
-    /// <example>"1, 0, 88 , -11,2" would return a dictionary with { {0,1}, {1, 0}, {2, 88}, {3,-11}, {4, 2} }</example>
-    public static IDictionary<int, int> GetIntDictionary(this string value, char splitter = ',')
-    {
-        IDictionary<int, int> result = null;
-
-        if (value?.GetIntList(splitter) is { } list)
+        /// <summary>
+        /// Gets an integer dictionary from a string with <paramref name="splitter"/> seperated integer values.
+        /// The first value of the dictionary is the position.
+        /// </summary>
+        /// <param name="value">The string with <paramref name="splitter"/> seperated integer values</param>
+        /// <param name="splitter">[optional] splitter; by default: ','</param>
+        /// <returns>If <paramref name="value"/> isn't <c>null</c>, a <see cref="IDictionary{TKey,TValue}"/> of the found integer values; otherwise <c>null</c></returns>
+        /// <example>"1, 0, 88 , -11,2" would return a dictionary with { {0,1}, {1, 0}, {2, 88}, {3,-11}, {4, 2} }</example>
+        public static IDictionary<int, int> GetIntDictionary(this string value, char splitter = ',')
         {
-            result = new Dictionary<int, int>(list.Count);
+            IDictionary<int, int> result = null;
 
-            for (var i = 0; i < list.Count; i++)
+            if (value?.GetIntList(splitter) is { } list)
             {
-                result.Add(i, list[i]);
-            }
-        }
+                result = new Dictionary<int, int>(list.Count);
 
-        return result;
+                for (var i = 0; i < list.Count; i++)
+                {
+                    result.Add(i, list[i]);
+                }
+            }
+
+            return result;
+        }
     }
 }

--- a/ahbsd.lib/Extensions/StringExtensions.cs
+++ b/ahbsd.lib/Extensions/StringExtensions.cs
@@ -1,0 +1,95 @@
+// 
+//     ahbsd.lib
+//     ahbsd.lib
+//     StringExtensions.cs
+// 
+//     Copyright 2023 Alexandra Hermann – Beratung, Software, Design
+// 
+//     Licensed under the Apache License, Version 2.0 (the "License");
+//     you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+// 
+//         http://www.apache.org/licenses/LICENSE-2.0
+// 
+//     Unless required by applicable law or agreed to in writing, software
+//     distributed under the License is distributed on an "AS IS" BASIS,
+//     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+//     limitations under the License.
+// 
+
+using System.Collections.Generic;
+
+namespace ahbsd.lib.Extensions;
+
+/// <summary>
+/// A static class for extensions for the <see cref="string"/> class.
+/// </summary>
+public static class StringExtensions
+{
+    /// <summary>
+    /// Indicates whether the specified string is <c>null</c> or an empty string ("").
+    /// </summary>
+    /// <param name="value">The string to test.</param>
+    /// <returns><c>true</c> if the value parameter is <c>null</c> or an empty string (""); otherwise, <c>false</c>.</returns>
+    public static bool IsNullOrEmpty(this string value) => string.IsNullOrEmpty(value);
+
+    /// <summary>
+    /// Indicates whether a specified string is <c>null</c>, empty, or consists only of white-space characters.
+    /// </summary>
+    /// <param name="value">The string to test.</param>
+    /// <returns><c>true</c> if the value parameter is <c>null</c> or <see cref="string.Empty"/>, or if value consists exclusively of white-space characters.</returns>
+    public static bool IsNullOrWhiteSpace(this string value) => string.IsNullOrWhiteSpace(value);
+
+    /// <summary>
+    /// Gets an integer list from a string with <paramref name="splitter"/> seperated integer values.
+    /// </summary>
+    /// <param name="value">The string with <paramref name="splitter"/> seperated integer values</param>
+    /// <param name="splitter">[optional] splitter; by default: ','</param>
+    /// <returns>If <paramref name="value"/> isn't <c>null</c>, a <see cref="IList{T}"/> of the found integer values; otherwise <c>null</c></returns>
+    /// <example>"1, 0, 88 , -11,2" would return a list with {1, 0, 88, -11, 2}</example>
+    public static IList<int> GetIntList(this string value, char splitter = ',')
+    {
+        IList<int> result = null;
+
+        if (value != null)
+        {
+            result = new List<int>();
+
+            foreach (var s in value.Split(splitter))
+            {
+                if (int.TryParse(s.Trim(), out var i))
+                {
+                    result.Add(i);
+                }
+            }
+        }
+
+        return result;
+    }
+    
+    /// <summary>
+    /// Gets an integer dictionary from a string with <paramref name="splitter"/> seperated integer values.
+    /// The first value of the dictionary is the position.
+    /// </summary>
+    /// <param name="value">The string with <paramref name="splitter"/> seperated integer values</param>
+    /// <param name="splitter">[optional] splitter; by default: ','</param>
+    /// <returns>If <paramref name="value"/> isn't <c>null</c>, a <see cref="IDictionary{TKey,TValue}"/> of the found integer values; otherwise <c>null</c></returns>
+    /// <example>"1, 0, 88 , -11,2" would return a dictionary with { {0,1}, {1, 0}, {2, 88}, {3,-11}, {4, 2} }</example>
+    public static IDictionary<int, int> GetIntDictionary(this string value, char splitter = ',')
+    {
+        IDictionary<int, int> result = null;
+
+        if (value?.GetIntList(splitter) is { } list)
+        {
+            result = new Dictionary<int, int>(list.Count);
+
+            for (var i = 0; i < list.Count; i++)
+            {
+                result.Add(i, list[i]);
+            }
+        }
+
+        return result;
+    }
+}

--- a/ahbsd.lib/Interfaces/IAsReadonlyCollection.cs
+++ b/ahbsd.lib/Interfaces/IAsReadonlyCollection.cs
@@ -20,17 +20,18 @@
 
 using System.Collections.Generic;
 
-namespace ahbsd.lib.Interfaces;
-
-/// <summary>
-/// Interface for getting a <see cref="IReadOnlyCollection{T}"/>
-/// </summary>
-/// <typeparam name="T">The type of the read only collection</typeparam>
-public interface IAsReadonlyCollection<out T>
+namespace ahbsd.lib.Interfaces
 {
     /// <summary>
-    /// Gets the collection as readonly connection.
+    /// Interface for getting a <see cref="IReadOnlyCollection{T}"/>
     /// </summary>
-    /// <value>The collection as readonly connection</value>
-    IReadOnlyCollection<T> AsReadonly { get; }
+    /// <typeparam name="T">The type of the read only collection</typeparam>
+    public interface IAsReadonlyCollection<out T>
+    {
+        /// <summary>
+        /// Gets the collection as readonly connection.
+        /// </summary>
+        /// <value>The collection as readonly connection</value>
+        IReadOnlyCollection<T> AsReadonly { get; }
+    }
 }

--- a/ahbsd.lib/Interfaces/ICollectionAddEventArgs.cs
+++ b/ahbsd.lib/Interfaces/ICollectionAddEventArgs.cs
@@ -22,18 +22,19 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
-namespace ahbsd.lib.Interfaces;
-
-/// <summary>
-/// Interface for generic event Args handling additions to <see cref="ICollection{T}"/>s.
-/// </summary>
-/// <typeparam name="T">The <see cref="Type"/> to use</typeparam>
-public interface ICollectionAddEventArgs<out T> : IEventArgs<T>
+namespace ahbsd.lib.Interfaces
 {
     /// <summary>
-    /// Gets the affected collection as read only.
+    /// Interface for generic event Args handling additions to <see cref="ICollection{T}"/>s.
     /// </summary>
-    /// <value>The affected collection as read only</value>
-    [NotNull]
-    IReadOnlyCollection<T> AffectedCollection { get; }
+    /// <typeparam name="T">The <see cref="Type"/> to use</typeparam>
+    public interface ICollectionAddEventArgs<out T> : IEventArgs<T>
+    {
+        /// <summary>
+        /// Gets the affected collection as read only.
+        /// </summary>
+        /// <value>The affected collection as read only</value>
+        [NotNull]
+        IReadOnlyCollection<T> AffectedCollection { get; }
+    }
 }

--- a/ahbsd.lib/Interfaces/ICollectionRemoveArgs.cs
+++ b/ahbsd.lib/Interfaces/ICollectionRemoveArgs.cs
@@ -20,17 +20,18 @@
 
 using System.Collections.Generic;
 
-namespace ahbsd.lib.Interfaces;
-
-/// <summary>
-/// Generic interface for removed item's.
-/// </summary>
-/// <typeparam name="T">The type of the event's</typeparam>
-public interface ICollectionRemoveArgs<out T>
+namespace ahbsd.lib.Interfaces
 {
     /// <summary>
-    /// Gets the removed items as readonly.
+    /// Generic interface for removed item's.
     /// </summary>
-    /// <value>The removed items as readonly</value>
-    IReadOnlyCollection<T> RemovedItems { get; }
+    /// <typeparam name="T">The type of the event's</typeparam>
+    public interface ICollectionRemoveArgs<out T>
+    {
+        /// <summary>
+        /// Gets the removed items as readonly.
+        /// </summary>
+        /// <value>The removed items as readonly</value>
+        IReadOnlyCollection<T> RemovedItems { get; }
+    }
 }

--- a/ahbsd.lib/Interfaces/IEventCollection.cs
+++ b/ahbsd.lib/Interfaces/IEventCollection.cs
@@ -21,26 +21,27 @@
 using System.Collections.Generic;
 using ahbsd.lib.EventHandler;
 
-namespace ahbsd.lib.Interfaces;
-
-/// <summary>
-/// Interface for a collection that has an event for adding or removing an item.
-/// </summary>
-/// <typeparam name="T">The type to use</typeparam>
-public interface IEventCollection<T> : ICollection<T>, IAsReadonlyCollection<T>
+namespace ahbsd.lib.Interfaces
 {
     /// <summary>
-    /// Happens when an item was added.
+    /// Interface for a collection that has an event for adding or removing an item.
     /// </summary>
-    event CollectionAddEventHandler<T> OnAdded;
+    /// <typeparam name="T">The type to use</typeparam>
+    public interface IEventCollection<T> : ICollection<T>, IAsReadonlyCollection<T>
+    {
+        /// <summary>
+        /// Happens when an item was added.
+        /// </summary>
+        event CollectionAddEventHandler<T> OnAdded;
 
-    /// <summary>
-    /// Happens when an item was removed.
-    /// </summary>
-    event CollectionRemoveArgsEventHandler<T> OnRemoved;
+        /// <summary>
+        /// Happens when an item was removed.
+        /// </summary>
+        event CollectionRemoveArgsEventHandler<T> OnRemoved;
 
-    /// <summary>
-    /// Happens when the dictionary is cleared.
-    /// </summary>
-    event CollectionRemoveArgsEventHandler<T> OnCleared;
+        /// <summary>
+        /// Happens when the dictionary is cleared.
+        /// </summary>
+        event CollectionRemoveArgsEventHandler<T> OnCleared;
+    }
 }

--- a/ahbsd.lib/Interfaces/IGetCaller.cs
+++ b/ahbsd.lib/Interfaces/IGetCaller.cs
@@ -20,17 +20,18 @@
 
 using System.Diagnostics;
 
-namespace ahbsd.lib.Interfaces;
-
-/// <summary>
-/// An interface for classes, that get the calling classes.
-/// </summary>
-/// <remarks>e.g. when a functionality like a set was called.</remarks>
-public interface IGetCaller
+namespace ahbsd.lib.Interfaces
 {
     /// <summary>
-    /// Gets the calling object.
+    /// An interface for classes, that get the calling classes.
     /// </summary>
-    /// <value>The calling object</value>
-    StackFrame Caller { get; }
+    /// <remarks>e.g. when a functionality like a set was called.</remarks>
+    public interface IGetCaller
+    {
+        /// <summary>
+        /// Gets the calling object.
+        /// </summary>
+        /// <value>The calling object</value>
+        StackFrame Caller { get; }
+    }
 }

--- a/ahbsd.lib/Interfaces/ILogger.cs
+++ b/ahbsd.lib/Interfaces/ILogger.cs
@@ -47,6 +47,12 @@ public interface ILogger
     /// </summary>
     /// <param name="e">The given exception</param>
     void Log(Exception e);
+
+    /// <summary>
+    /// If a logger is available, the given <see cref="object.ToString()"/> will be logged.
+    /// </summary>
+    /// <param name="o">The given object</param>
+    void Log(object o);
         
     /// <summary>
     /// Gets the name of this logger.

--- a/ahbsd.lib/Interfaces/ILogger.cs
+++ b/ahbsd.lib/Interfaces/ILogger.cs
@@ -22,52 +22,53 @@ using System;
 using System.IO;
 using ahbsd.lib.EventHandler;
 
-namespace ahbsd.lib.Interfaces;
-
-/// <summary>
-/// Interface for a simple logger.
-/// </summary>
-public interface ILogger
+namespace ahbsd.lib.Interfaces
 {
-
     /// <summary>
-    /// If a logger is available, the given message is logged.
+    /// Interface for a simple logger.
     /// </summary>
-    /// <param name="message">The given message</param>
-    void Log(string message);
+    public interface ILogger
+    {
 
-    /// <summary>
-    /// If a logger is available, the given error event arguments are logged.
-    /// </summary>
-    /// <param name="e">The given error event arguments</param>
-    void Log(ErrorEventArgs e);
+        /// <summary>
+        /// If a logger is available, the given message is logged.
+        /// </summary>
+        /// <param name="message">The given message</param>
+        void Log(string message);
 
-    /// <summary>
-    /// If a logger is available, the given exception message will be logged.
-    /// </summary>
-    /// <param name="e">The given exception</param>
-    void Log(Exception e);
+        /// <summary>
+        /// If a logger is available, the given error event arguments are logged.
+        /// </summary>
+        /// <param name="e">The given error event arguments</param>
+        void Log(ErrorEventArgs e);
 
-    /// <summary>
-    /// If a logger is available, the given <see cref="object.ToString()"/> will be logged.
-    /// </summary>
-    /// <param name="o">The given object</param>
-    void Log(object o);
+        /// <summary>
+        /// If a logger is available, the given exception message will be logged.
+        /// </summary>
+        /// <param name="e">The given exception</param>
+        void Log(Exception e);
+
+        /// <summary>
+        /// If a logger is available, the given <see cref="object.ToString()"/> will be logged.
+        /// </summary>
+        /// <param name="o">The given object</param>
+        void Log(object o);
         
-    /// <summary>
-    /// Gets the name of this logger.
-    /// </summary>
-    /// <value>The name of this logger</value>
-    string Name { get; }
+        /// <summary>
+        /// Gets the name of this logger.
+        /// </summary>
+        /// <value>The name of this logger</value>
+        string Name { get; }
         
-    /// <summary>
-    /// Gets or sets the path to the logfile.
-    /// </summary>
-    string Logfile { get; set; }
+        /// <summary>
+        /// Gets or sets the path to the logfile.
+        /// </summary>
+        string Logfile { get; set; }
 
-    /// <summary>
-    /// Happens, when the path of the logfile has changed.
-    /// </summary>
-    event ChangeEventHandler<string> OnLogfileChanged; 
+        /// <summary>
+        /// Happens, when the path of the logfile has changed.
+        /// </summary>
+        event ChangeEventHandler<string> OnLogfileChanged; 
 
+    }
 }

--- a/ahbsd.lib/Interfaces/ISourceDirectories.cs
+++ b/ahbsd.lib/Interfaces/ISourceDirectories.cs
@@ -21,21 +21,22 @@
 using System.Collections.Generic;
 using ahbsd.lib.EventHandler;
 
-namespace ahbsd.lib.Interfaces;
-
-/// <summary>
-/// Interface for source directories.
-/// </summary>
-public interface ISourceDirectories : ICollection<string>
+namespace ahbsd.lib.Interfaces
 {
     /// <summary>
-    /// Happens, when a new directory was added.
+    /// Interface for source directories.
     /// </summary>
-    event CollectionAddEventHandler<string> OnNewDirectoryAdded;
+    public interface ISourceDirectories : ICollection<string>
+    {
+        /// <summary>
+        /// Happens, when a new directory was added.
+        /// </summary>
+        event CollectionAddEventHandler<string> OnNewDirectoryAdded;
         
-    /// <summary>
-    /// Gets this collection as read only collection.
-    /// </summary>
-    /// <value>This collection as read only collection</value>
-    IReadOnlyCollection<string> AsReadonly { get; }
+        /// <summary>
+        /// Gets this collection as read only collection.
+        /// </summary>
+        /// <value>This collection as read only collection</value>
+        IReadOnlyCollection<string> AsReadonly { get; }
+    }
 }

--- a/ahbsd.lib/NamedCollections/DictionaryOfNamedCollection.cs
+++ b/ahbsd.lib/NamedCollections/DictionaryOfNamedCollection.cs
@@ -35,35 +35,22 @@ namespace ahbsd.lib.NamedCollections
         /// </summary>
         /// <param name="info">The serialization info</param>
         /// <param name="context">The streaming context</param>
-        protected DictionaryOfNamedCollection(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-            //
-        }
+        protected DictionaryOfNamedCollection(SerializationInfo info, StreamingContext context) : base(info, context) { }
 
         /// <summary>
         /// Simple constructor
         /// </summary>
-        public DictionaryOfNamedCollection()
-        {
-            //
-        }
+        public DictionaryOfNamedCollection() { }
         
         #region implementation of IDictionaryOfNamedCollections<K, V>
-        /// <summary>
-        /// Happens if a new <see cref="INamedCollection{T}"/> was added.
-        /// </summary>
+        /// <inheritdoc />
         public event EventHandler<EventArgs<INamedCollection<V>>> OnNamedCollectionAdded;
-        /// <summary>
-        /// Adds a new key with the name of the new <see cref="INamedCollection{T}"/>.
-        /// </summary>
-        /// <param name="key">The new key.</param>
-        /// <param name="name">The name of the new <see cref="INamedCollection{T}"/>.</param>
-        /// <exception cref="ArgumentException">If key already exists.</exception>
+        
+        /// <inheritdoc />
         public void Add(K key, string name)
         {
             Type t = typeof(V);
-            if (t.Equals(typeof(string)))
+            if (t == typeof(string))
             {
                 V tmpV = (V)Convert.ChangeType(name, t);
                 Add(key, tmpV);
@@ -79,70 +66,38 @@ namespace ahbsd.lib.NamedCollections
                 }
                 else
                 {
-                    ArgumentException ae = new(
-                        $"Key '{key}' already exists.",
-                        "key");
+                    ArgumentException ae = new($"Key '{key}' already exists.", nameof(key));
                     throw ae;
                 }
             }
         }
-        /// <summary>
-        /// Adds a value to the <see cref="INamedCollection{T}"/> of key.
-        /// </summary>
-        /// <param name="key">The Key.</param>
-        /// <param name="value">The Value.</param>
-        /// <param name="name">[optional] 
-        /// The name of the new <see cref="INamedCollection{T}"/>.
-        /// </param>
-        /// <remarks>
-        /// If the key already exists the name isn't needed; if the key doesn't
-        /// exists a name is needed, otherwise a
-        /// <see cref="KeyNotFoundException"/> will be thrown.
-        /// </remarks>
-        /// <exception cref="KeyNotFoundException">
-        /// If the key isn't there AND a name for the new
-        /// <see cref="INamedCollection{T}"/> was missing.
-        /// </exception>
+        
+        /// <inheritdoc />
         public void Add(K key, V value, string name = null)
         {
             if (!ContainsKey(key))
             {
                 if (name.IsNullOrEmpty())
                 {
-                    KeyNotFoundException k =
-                        new($"Key '{key}' is missing AND name" +
-                            $"for creating a new INamedCollection<{typeof(V)}> " +
-                            "is null or empty as well");
+                    KeyNotFoundException k = new($"Key '{key}' is missing AND name for creating a new INamedCollection<{typeof(V)}> is null or empty as well");
                     throw k;
                 }
 
-                EventArgs<INamedCollection<V>> eventArgs;
                 INamedCollection<V> tmp = new NamedCollection<V>(name);
-                eventArgs = new EventArgs<INamedCollection<V>>(tmp);
+                var eventArgs = new EventArgs<INamedCollection<V>>(tmp);
                 Add(key, tmp);
                 OnNamedCollectionAdded?.Invoke(this, eventArgs);
             }
 
             this[key].Add(value);
         }
-        /// <summary>
-        /// Adds a <see cref="KeyValuePair{TKey, TValue}"/>.
-        /// </summary>
-        /// <param name="keyValuePair">The <see cref="KeyValuePair{TKey, TValue}"/>.</param>
-        /// <param name="name">[optional] 
-        /// The name of the new <see cref="INamedCollection{T}"/>.
-        /// </param>
-        /// <remarks>
-        /// If the key already exists the name isn't needed; if the key doesn't
-        /// exists a name is needed, otherwise a
-        /// <see cref="KeyNotFoundException"/> will be thrown.
-        /// </remarks>
-        /// <exception cref="KeyNotFoundException">
-        /// If the key isn't there AND a name for the new
-        /// <see cref="INamedCollection{T}"/> was missing.
-        /// </exception>
+        
+        /// <inheritdoc />
         public void Add(KeyValuePair<K, V> keyValuePair, string name = null)
             => Add(keyValuePair.Key, keyValuePair.Value, name);
         #endregion
+
+        /// <inheritdoc />
+        public override string ToString() => $"DictionaryOfNamedCollection<{typeof(K)}, {typeof(V)}>; Count: {Count}";
     }
 }

--- a/ahbsd.lib/NamedCollections/DictionaryOfNamedCollection.cs
+++ b/ahbsd.lib/NamedCollections/DictionaryOfNamedCollection.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using ahbsd.lib.Extensions;
 
 namespace ahbsd.lib.NamedCollections
 {
@@ -106,7 +107,7 @@ namespace ahbsd.lib.NamedCollections
         {
             if (!ContainsKey(key))
             {
-                if (string.IsNullOrEmpty(name))
+                if (name.IsNullOrEmpty())
                 {
                     KeyNotFoundException k =
                         new($"Key '{key}' is missing AND name" +

--- a/ahbsd.lib/NamedCollections/DictionaryOfNamedCollection.cs
+++ b/ahbsd.lib/NamedCollections/DictionaryOfNamedCollection.cs
@@ -60,13 +60,12 @@ namespace ahbsd.lib.NamedCollections
                 if (!ContainsKey(key))
                 {
                     Add(key, new NamedCollection<V>(name));
-                    EventArgs<INamedCollection<V>> eventArgs =
-                        new(new NamedCollection<V>(name));
+                    EventArgs<INamedCollection<V>> eventArgs = new EventArgs<INamedCollection<V>>(new NamedCollection<V>(name));
                     OnNamedCollectionAdded?.Invoke(this, eventArgs);
                 }
                 else
                 {
-                    ArgumentException ae = new($"Key '{key}' already exists.", nameof(key));
+                    ArgumentException ae = new ArgumentException($"Key '{key}' already exists.", nameof(key));
                     throw ae;
                 }
             }
@@ -79,7 +78,7 @@ namespace ahbsd.lib.NamedCollections
             {
                 if (name.IsNullOrEmpty())
                 {
-                    KeyNotFoundException k = new($"Key '{key}' is missing AND name for creating a new INamedCollection<{typeof(V)}> is null or empty as well");
+                    KeyNotFoundException k = new KeyNotFoundException($"Key '{key}' is missing AND name for creating a new INamedCollection<{typeof(V)}> is null or empty as well");
                     throw k;
                 }
 

--- a/ahbsd.lib/NamedCollections/DictionaryOfNamedList.cs
+++ b/ahbsd.lib/NamedCollections/DictionaryOfNamedList.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using ahbsd.lib.Extensions;
 
 // ReSharper disable All
 
@@ -105,7 +106,7 @@ namespace ahbsd.lib.NamedCollections
         {
             if (!ContainsKey(key))
             {
-                if (string.IsNullOrEmpty(name))
+                if (name.IsNullOrEmpty())
                 {
                     KeyNotFoundException k =
                         new($"Key '{key}' is missing AND name" +

--- a/ahbsd.lib/NamedCollections/DictionaryOfNamedList.cs
+++ b/ahbsd.lib/NamedCollections/DictionaryOfNamedList.cs
@@ -58,14 +58,12 @@ namespace ahbsd.lib.NamedCollections
                 if (!ContainsKey(key))
                 {
                     Add(key, new NamedList<V>(name));
-                    EventArgs<INamedList<V>> eventArgs = new(new NamedList<V>(name));
+                    EventArgs<INamedList<V>> eventArgs = new EventArgs<INamedList<V>>(new NamedList<V>(name));
                     OnNamedListAdded?.Invoke(this, eventArgs);
                 }
                 else
                 {
-                    ArgumentException ae = new(
-                        $"Key '{key}' already exists.",
-                        "key");
+                    ArgumentException ae = new ArgumentException($"Key '{key}' already exists.", "key");
                     throw ae;
                 }
             }
@@ -78,14 +76,14 @@ namespace ahbsd.lib.NamedCollections
             {
                 if (name.IsNullOrEmpty())
                 {
-                    KeyNotFoundException k = new($"Key '{key}' is missing AND name for creating a new INamedList<{typeof(V)}> is null or empty as well");
+                    KeyNotFoundException k = new KeyNotFoundException($"Key '{key}' is missing AND name for creating a new INamedList<{typeof(V)}> is null or empty as well");
                     throw k;
                 }
                 else
                 {
                     var namedList = new NamedList<V>(name);
                     Add(key, namedList);
-                    EventArgs<INamedList<V>> eventArgs = new(namedList);
+                    EventArgs<INamedList<V>> eventArgs = new EventArgs<INamedList<V>>(namedList);
                     OnNamedListAdded?.Invoke(this, eventArgs);
                 }
             }

--- a/ahbsd.lib/NamedCollections/DictionaryOfNamedList.cs
+++ b/ahbsd.lib/NamedCollections/DictionaryOfNamedList.cs
@@ -35,32 +35,17 @@ namespace ahbsd.lib.NamedCollections
         /// </summary>
         /// <param name="info">The serialization info</param>
         /// <param name="context">The streaming context</param>
-        protected DictionaryOfNamedList(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-            //
-        }
+        protected DictionaryOfNamedList(SerializationInfo info, StreamingContext context) : base(info, context) { }
 
         /// <summary>
         /// Simple constructor
         /// </summary>
-        public DictionaryOfNamedList()
-            : base()
-        {
-            //
-        }
+        public DictionaryOfNamedList() : base() { }
         
         #region implementation of IDictionaryOfNamedList<K, V>
-        /// <summary>
-        /// Happens, if a new <see cref="INamedList{T}"/> was added.
-        /// </summary>
+        /// <inheritdoc />
         public event EventHandler<EventArgs<INamedList<V>>> OnNamedListAdded;
-        /// <summary>
-        /// Adds a key.
-        /// </summary>
-        /// <param name="key">The key.</param>
-        /// <param name="name">The name of the new <see cref="INamedList{T}"/>.</param>
-        /// <exception cref="ArgumentException">If key already exists.</exception>
+        /// <inheritdoc />
         public void Add(K key, string name)
         {
             if (typeof(V).Equals(typeof(string)))
@@ -85,62 +70,34 @@ namespace ahbsd.lib.NamedCollections
                 }
             }
         }
-        /// <summary>
-        /// Adds a value to the <see cref="INamedList{T}"/> of key.
-        /// </summary>
-        /// <param name="key">The key.</param>
-        /// <param name="value">The value.</param>
-        /// <param name="name">[optional] 
-        /// The name of the new <see cref="INamedList{T}"/>.
-        /// </param>
-        /// <remarks>
-        /// If the key already exists the name isn't needed; if the key doesn't
-        /// exists a name is needed, otherwise a
-        /// <see cref="KeyNotFoundException"/> will be thrown.
-        /// </remarks>
-        /// <exception cref="KeyNotFoundException">
-        /// If the key isn't there AND a name for the new
-        /// <see cref="INamedList{T}"/> was missing.
-        /// </exception>
+        
+        /// <inheritdoc />
         public void Add(K key, V value, string name = null)
         {
             if (!ContainsKey(key))
             {
                 if (name.IsNullOrEmpty())
                 {
-                    KeyNotFoundException k =
-                        new($"Key '{key}' is missing AND name" +
-                            $"for creating a new INamedList<{typeof(V)}> is null or empty as well");
+                    KeyNotFoundException k = new($"Key '{key}' is missing AND name for creating a new INamedList<{typeof(V)}> is null or empty as well");
                     throw k;
                 }
                 else
                 {
-                    Add(key, new NamedList<V>(name));
-                    EventArgs<INamedList<V>> eventArgs = new(new NamedList<V>(name));
+                    var namedList = new NamedList<V>(name);
+                    Add(key, namedList);
+                    EventArgs<INamedList<V>> eventArgs = new(namedList);
                     OnNamedListAdded?.Invoke(this, eventArgs);
                 }
             }
 
             this[key].Add(value);
         }
-        /// <summary>
-        /// Adds a <see cref="KeyValuePair{TKey, TValue}"/>.
-        /// </summary>
-        /// <param name="keyValuePair">The <see cref="KeyValuePair{TKey, TValue}"/>.</param>
-        /// <param name="name">[optional] 
-        /// The name of the new <see cref="INamedList{T}"/>.
-        /// </param>
-        /// <remarks>
-        /// If the key already exists the name isn't needed; if the key doesn't
-        /// exists a name is needed, otherwise a
-        /// <see cref="KeyNotFoundException"/> will be thrown.
-        /// </remarks>
-        /// <exception cref="KeyNotFoundException">
-        /// If the key isn't there AND a name for the new
-        /// <see cref="INamedList{T}"/> was missing.
-        /// </exception>
-        public void Add(KeyValuePair<K, V> keyValuePair, string name = null)
-            => Add(keyValuePair.Key, keyValuePair.Value, name);
+        
+        /// <inheritdoc />
+        public void Add(KeyValuePair<K, V> keyValuePair, string name = null) => Add(keyValuePair.Key, keyValuePair.Value, name);
         #endregion
+
+        /// <inheritdoc />
+        public override string ToString() => $"DictionaryOfNamedList<{typeof(K)}, {typeof(V)}>; Count={Count}";
     }
 }

--- a/ahbsd.lib/NamedCollections/NamedList.cs
+++ b/ahbsd.lib/NamedCollections/NamedList.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using ahbsd.lib.EventArgs;
 using ahbsd.lib.EventHandler;
 
@@ -40,15 +41,14 @@ namespace ahbsd.lib.NamedCollections
         /// Constructor with a base capacity of the list.
         /// </summary>
         /// <param name="capacity">The base capacity of the list.</param>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// If the capacity is out of range.
-        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less then 0</exception>
         public NamedList(int capacity) : base(capacity) => name = null;
 
         /// <summary>
         /// Constructor with a given collection.
         /// </summary>
         /// <param name="collection">The given collection.</param>
+        /// <exception cref="ArgumentException"><paramref name="collection"/> is <c>null</c></exception>
         public NamedList(IEnumerable<T> collection) : base(collection) => name = null;
 
         /// <summary>
@@ -62,9 +62,7 @@ namespace ahbsd.lib.NamedCollections
         /// </summary>
         /// <param name="name">The given name.</param>
         /// <param name="capacity">The base capacity of the list.</param>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// If the capacity is out of range.
-        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less then 0</exception>
         public NamedList(string name, int capacity) : base(capacity) => this.name = name?.Trim();
 
         /// <summary>
@@ -72,8 +70,8 @@ namespace ahbsd.lib.NamedCollections
         /// </summary>
         /// <param name="name">The given name.</param>
         /// <param name="collection">The given collection.</param>
-        public NamedList(string name, IEnumerable<T> collection) : base(collection) => this.name = name?.Trim();
-
+        /// <exception cref="ArgumentException"><paramref name="collection"/> is <c>null</c></exception>
+        public NamedList(string name, [NotNull]IEnumerable<T> collection) : base(collection) => this.name = name?.Trim();
 
         #region implementation of INamedList<T>
         /// <inheritdoc/>
@@ -102,11 +100,8 @@ namespace ahbsd.lib.NamedCollections
         /// <inheritdoc/>
         public event ChangeEventHandler<string> OnNameChanged;
 
-        /// <summary>
-        /// Gets a string representation of this object.
-        /// </summary>
-        /// <returns>The string representation of this object.</returns>
-        public override string ToString() => $"{name}: Count = {Count}";
+        /// <inheritdoc cref="object.ToString()"/>
+        public override string ToString() => $"{name}List<{typeof(T)}>: Count = {Count}";
         #endregion
     }
 }

--- a/ahbsd.lib/Password/CharacteristicDictionary.cs
+++ b/ahbsd.lib/Password/CharacteristicDictionary.cs
@@ -201,7 +201,7 @@ namespace ahbsd.lib.Password
         /// <inheritdoc cref="ICharacteristicDictionary.ToString"/>
         public override string ToString()
         {
-            StringBuilder result = new("CharacteristicDictionary ");
+            StringBuilder result = new StringBuilder("CharacteristicDictionary ");
             int added = 0;
 
             if (this[Charasteristic.CapitalLetter])

--- a/ahbsd.lib/Password/Check/SecurityValue.cs
+++ b/ahbsd.lib/Password/Check/SecurityValue.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using ahbsd.lib.Extensions;
 
 namespace ahbsd.lib.Password.Check
 {
@@ -99,7 +100,7 @@ namespace ahbsd.lib.Password.Check
         private void Initialize()
         {
             uint tmp = 0;
-            if (Password != null && !string.IsNullOrEmpty(Password.Value))
+            if (Password != null && !Password.Value.IsNullOrEmpty())
             {
                 tmp = (uint)Password.Length;
                 tmp += (uint)Password.LowerCases;

--- a/ahbsd.lib/Password/Password.cs
+++ b/ahbsd.lib/Password/Password.cs
@@ -180,7 +180,7 @@ namespace ahbsd.lib.Password
                 {
                     var tmp = GetTemporaryPassword(value);
                     
-                    ChangeEventArgs<IPassword> cea = new(MemberwiseClone() as IPassword, tmp);
+                    ChangeEventArgs<IPassword> cea = new ChangeEventArgs<IPassword>(MemberwiseClone() as IPassword, tmp);
 
                     this.value = value;
                     SecurityValue = tmp.SecurityValue;

--- a/ahbsd.lib/Password/Password.cs
+++ b/ahbsd.lib/Password/Password.cs
@@ -19,6 +19,7 @@ using System.ComponentModel;
 using System.Linq;
 using ahbsd.lib.EventArgs;
 using ahbsd.lib.EventHandler;
+using ahbsd.lib.Extensions;
 using ahbsd.lib.Password.Check;
 
 namespace ahbsd.lib.Password
@@ -175,7 +176,7 @@ namespace ahbsd.lib.Password
             get => value;
             set
             {
-                if (!string.IsNullOrWhiteSpace(value) && !value.Equals(this.value))
+                if (!value.IsNullOrWhiteSpace() && !value.Equals(this.value))
                 {
                     var tmp = GetTemporaryPassword(value);
                     
@@ -283,7 +284,7 @@ namespace ahbsd.lib.Password
         /// <param name="value">The given string.</param>
         /// <returns>The amount of lower cases.</returns>
         public static int GetLowerCases(string value) 
-            => !string.IsNullOrWhiteSpace(value)
+            => !value.IsNullOrWhiteSpace()
                 ? (from char c in value
                     where char.IsLower(c)
                     select c).Count()
@@ -295,7 +296,7 @@ namespace ahbsd.lib.Password
         /// <param name="value">The given string.</param>
         /// <returns>The amount of upper cases.</returns>
         public static int GetUpperCases(string value) 
-            => !string.IsNullOrWhiteSpace(value)
+            => !value.IsNullOrWhiteSpace()
                 ? (from char c in value
                     where char.IsUpper(c)
                     select c).Count()
@@ -307,7 +308,7 @@ namespace ahbsd.lib.Password
         /// <param name="value">The given string.</param>
         /// <returns>The amount of spaces.</returns>
         public static int GetSpaces(string value) 
-            => !string.IsNullOrEmpty(value)
+            => !value.IsNullOrEmpty()
                 ? (from char c in value
                     where char.IsWhiteSpace(c)
                     select c).Count()
@@ -319,7 +320,7 @@ namespace ahbsd.lib.Password
         /// <param name="value">The given string.</param>
         /// <returns>The amount of numbers.</returns>
         public static int GetNumbers(string value) 
-            => !string.IsNullOrWhiteSpace(value)
+            => !value.IsNullOrWhiteSpace()
                 ? (from char c in value
                     where char.IsNumber(c)
                     select c).Count()
@@ -331,7 +332,7 @@ namespace ahbsd.lib.Password
         /// <param name="value">The given string.</param>
         /// <returns>The amount of special chars.</returns>
         public static int GetSpecials(string value) 
-            => !string.IsNullOrWhiteSpace(value) 
+            => !value.IsNullOrWhiteSpace() 
                 ? value.Count(ctmp => GetCharasteristic(ctmp) == Charasteristic.SpecialCharacter) 
                 : 0;
 

--- a/ahbsd.lib/Tools/Logger.cs
+++ b/ahbsd.lib/Tools/Logger.cs
@@ -22,6 +22,7 @@ using System;
 using System.IO;
 using ahbsd.lib.EventArgs;
 using ahbsd.lib.EventHandler;
+using ahbsd.lib.Extensions;
 using ahbsd.lib.Interfaces;
 
 namespace ahbsd.lib.Tools;
@@ -76,7 +77,7 @@ namespace ahbsd.lib.Tools;
             Exception maybeException = null;
             
             // if we have a previous log, we should dispose it.
-            if (!string.IsNullOrWhiteSpace(e.OldValue) && logWriter != null)
+            if (!e.OldValue.IsNullOrWhiteSpace() && logWriter != null)
             {
                 try
                 {
@@ -96,7 +97,7 @@ namespace ahbsd.lib.Tools;
                 }
             }
             
-            if (!string.IsNullOrWhiteSpace(e.NewValue))
+            if (!e.NewValue.IsNullOrWhiteSpace())
             {
                 logWriter = File.AppendText(e.NewValue);
                 logWriter.AutoFlush = true;
@@ -152,7 +153,7 @@ namespace ahbsd.lib.Tools;
             {
                 ChangeEventArgs<string> changeEventArgs = new ChangeEventArgs<string>(logfilePath, value);
 
-                if (!string.IsNullOrWhiteSpace(value) && !value.Equals(logfilePath))
+                if (!value.IsNullOrWhiteSpace() && !value.Equals(logfilePath))
                 {
                     logfilePath = value;
                     OnLogfileChanged?.Invoke(this, changeEventArgs);

--- a/ahbsd.lib/Tools/Logger.cs
+++ b/ahbsd.lib/Tools/Logger.cs
@@ -99,17 +99,25 @@ namespace ahbsd.lib.Tools;
             
             if (!e.NewValue.IsNullOrWhiteSpace())
             {
-                logWriter = File.AppendText(e.NewValue);
-                logWriter.AutoFlush = true;
-                isDisposed = false;
+                try
+                {
+                    logWriter = File.AppendText(e.NewValue);
+                    logWriter.AutoFlush = true;
+                    isDisposed = false;
                 
-                var filename = GetFilename(e.NewValue, out var alreadyExists);
+                    var filename = GetFilename(e.NewValue, out var alreadyExists);
 
-                var newFile = alreadyExists ? "the existing" : "the new";
+                    var newFile = alreadyExists ? "the existing" : "the new";
                 
-                Log($"A new log started with {newFile} logfile '{filename}' in logger {Name}.");
+                    Log($"A new log started with {newFile} logfile '{filename}' in logger {Name}.");
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex);
+                    maybeException = ex;
+                }
 
-                if (maybeException != null)
+                if (maybeException != null && logWriter != null)
                 {
                     Log(maybeException);
                 }
@@ -178,6 +186,9 @@ namespace ahbsd.lib.Tools;
         /// <inheritdoc/>
         public void Log(Exception e) 
             => logWriter?.WriteLine($"{DateTime.Now.ToUniversalTime()} – a {e.GetType().Name} happened: {e.Message}");
+
+        /// <inheritdoc/>
+        public void Log(object o) => Log(o?.ToString());
         
         #endregion
 

--- a/ahbsd.lib/Tools/Logger.cs
+++ b/ahbsd.lib/Tools/Logger.cs
@@ -25,9 +25,9 @@ using ahbsd.lib.EventHandler;
 using ahbsd.lib.Extensions;
 using ahbsd.lib.Interfaces;
 
-namespace ahbsd.lib.Tools;
-
-/// <summary>
+namespace ahbsd.lib.Tools
+{
+    /// <summary>
     /// A simple Logger
     /// </summary>
     public class Logger : ILogger, IDisposable
@@ -232,3 +232,4 @@ namespace ahbsd.lib.Tools;
         }
         #endregion
     }
+}

--- a/ahbsd.lib/ahbsd.lib.csproj
+++ b/ahbsd.lib/ahbsd.lib.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PackOnBuild>true</PackOnBuild>
     <PackageId>ahbsd.lib</PackageId>
-    <PackageVersion>1.5</PackageVersion>
+    <PackageVersion>1.6</PackageVersion>
     <Authors>Heinrich Alexandra Hermann</Authors>
     <Company>Alexandra Hermann – Beratung, Software, Design</Company>
     <Copyright>Apache 2.0</Copyright>
@@ -45,5 +45,19 @@
     <Folder Include="Password\Check\" />
     <Folder Include="NamedCollections\" />
     <Folder Include="Products\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\LICENSE.md">
+      <Link>LICENSE.md</Link>
+    </Content>
+    <Content Include="..\README.md">
+      <Link>README.md</Link>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/ahbsd.lib/ahbsd.lib.csproj
+++ b/ahbsd.lib/ahbsd.lib.csproj
@@ -23,7 +23,7 @@
     <SynchReleaseVersion>false</SynchReleaseVersion>
     <AssemblyName>ahbsd.lib_Core3.1</AssemblyName>
     <CodePage>65001</CodePage>
-    <LangVersion>latestmajor</LangVersion>
+    <LangVersion>8</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 


### PR DESCRIPTION
Simplifing `string.IsNullOrEmpty()` and `string.IsNullOrWhiteSpace()` and the extraction of numbered lists in a `string`.

### Example for the extraction
If you have a numbered list, e.g.: `"1,2, 5, 99 ,8"` and want to get an *array* or *List* with the numbers, you can solve it e.g. like this:

```c#
string numberedList = "1,2, 5, 99 ,8";

// for a result array:
string[] numbers = numberedList.Split(',');
int[] intNumbers = new int[numbers.Count];

for (int i = 0; i < numbers.Count; i++)
{
    if (int.TryParse(numbers[i].Trim(), out int number)
    {
        intNumbers[i] = number;
    }
}

// for a result list:
IList<int> numberList = new List<int>();

foreach (string sNumber in numberedList.Split(','))
{
    if (int.TryParse(sNumber.Trim(), out int number)
    {
        numberList.Add(number);
    }
}
```

much shorter (because the last part is more ore less included) is the following:

```c#
string numberedList = "1,2, 5, 99 ,8";
IList<int> numberList = numberedList.GetIntList();
```

additionally the Extension also allows to set the splitter:

```c#
string numberedList = "1;2; 5; 99 ;8";
IList<int> numberList = numberedList.GetIntList(';');
```